### PR TITLE
remove binstub before create

### DIFF
--- a/lib/busser/command/setup.rb
+++ b/lib/busser/command/setup.rb
@@ -46,6 +46,7 @@ module Busser
         binstub = root_path + "bin/busser"
 
         info "Creating busser binstub"
+        File.unlink(binstub) if File.exists?(binstub)
         create_file(binstub, :verbose => false) do
           <<-BUSSER_BINSTUB.gsub(/^ {12}/, '')
             #!/usr/bin/env sh


### PR DESCRIPTION
`create_file` method provides by Thor asks overwrite policy when file already exist.

```
-----> Starting Kitchen (v1.1.1)
-----> Setting up <ipfilter-sm-base64>...
-----> Setting up Busser
       Creating BUSSER_ROOT in /tmp/busser
       Creating busser binstub
Overwrite /tmp/busser/bin/busser? (enter "h" for help) [Ynaqdh]
```
