### PR TITLE
FIX: binstub fails to execute on SmartOS.

### DIFF
--- a/lib/busser/command/setup.rb
+++ b/lib/busser/command/setup.rb
@@ -62,7 +62,7 @@ module Busser
             # resolved path.
             SOURCE="#{ruby_bin}"
             while [ -h "$SOURCE" ] ; do SOURCE="`readlink "$SOURCE"`"; done
-            DIR="`cd -P \\"\\`dirname "$SOURCE"\\`\\" && pwd`"
+            DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
             # Set Busser Root path
             BUSSER_ROOT="#{root_path}"


### PR DESCRIPTION
Propably other Unices as well.

Tested on
- SmartOS   (sh == ksh)
- Ubuntu 12.04  (sh ==dash )
- Centos 6.5 (sh == ??)
