### PR TITLE
Aggressively pin Aruba to 0.7.4 to prevent API churn.

### DIFF
--- a/busser.gemspec
+++ b/busser.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'thor', '<= 0.19.0'
 
-  spec.add_development_dependency 'aruba'
+  spec.add_development_dependency 'aruba', "0.7.4"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'countloc'


### PR DESCRIPTION
Unfortunately, there were many breaking API changes in Aruba 0.8.0 and
up which require altering of ENV tests to be modified (among other
things). As a result, this change preserves the passing state of this
codebase as of the start of July 2015.