### PR TITLE
Add http_proxy support to `busser plugin install`.

### DIFF
--- a/lib/busser/command/plugin_install.rb
+++ b/lib/busser/command/plugin_install.rb
@@ -38,7 +38,15 @@ module Busser
       class_option :force_postinstall, :type => :boolean, :default => false,
         :desc => "Run the plugin's postinstall if it is already installed"
 
+      class_option :verbose, :type => :boolean, :default => false,
+        :desc => "Set a more verbose output"
+
       def install_all
+        if options[:verbose]
+          Gem.configuration.verbose = 2 if options[:verbose]
+          info("Using http_proxy=#{rbg_options[:http_proxy].inspect}")
+        end
+
         silence_gem_ui do
           plugins.each { |plugin| install(plugin) }
         end

--- a/lib/busser/cucumber.rb
+++ b/lib/busser/cucumber.rb
@@ -111,7 +111,7 @@ Then(/^a bat busser binstub file should contain:$/) do |partial_content|
 end
 
 Then(/^the file "(.*?)" should have permissions "(.*?)"$/) do |file, perms|
-  in_current_dir do
+  in_current_directory do
     file_perms = sprintf("%o", File.stat(file).mode)
     file_perms = file_perms[2, 4]
     expect(file_perms).to eq(perms)


### PR DESCRIPTION
This change will detect and use either the `http_proxy` or the
`HTTP_PROXY` environment variable when performing the plugin
installations, which delegate into RubyGems `gem install` code. This
delivers the functional equivalent behavior of running:

    gem install busser-<PLUGIN> --http-proxy http://proxy.local:8123

As the RubyGems install code had to be revisited, an alternative
implementation that is much simpler and (anecdotally) faster was used.
Using `Gem::Dependency.new(name, version).matching_specs` means we can
avoid any network calls to see if any installed plugin version satisfies
the version requirement. There is a small change in behavior where prior
to this the latest version was always checked, but given Busser's role
as a helper on an ephemeral testing node, there shouldn't be a pressing
need to update a plugin version (i.e. "if you ask for it to be installed
and there is any version, use it!").

Finally, a new optional flag `--verbose` is added to the
`busser plugin install` command which helps output the http_proxy server
used (if any) and the HTTP calls to the RubyGems API services. A future
version of Test Kitchen may use this flag when it is invoked with a
debug log level.