### PR TITLE
Remove pin on bundler 1.x

### DIFF
--- a/busser.gemspec
+++ b/busser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '<= 0.19.0'
 
   spec.add_development_dependency 'aruba', "0.7.4"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'countloc'
   spec.add_development_dependency 'fakefs'


### PR DESCRIPTION
This prevents the installation of this gem on modern ruby releases

Signed-off-by: Tim Smith <tsmith@chef.io>