### PR TITLE
Optimize our requires

### DIFF
--- a/bin/busser
+++ b/bin/busser
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 
 $:.unshift File.join(File.dirname(__FILE__), %w{.. lib})
-require 'rubygems'
+require 'rubygems' unless defined?(Gem)
 require 'busser/cli'
 
 Busser::CLI.start

--- a/lib/busser.rb
+++ b/lib/busser.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'pathname'
+require 'pathname' unless defined?(Pathname)
 
 require 'busser/version'
 

--- a/lib/busser/command/deserialize.rb
+++ b/lib/busser/command/deserialize.rb
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'base64'
-require 'digest'
+require 'base64' unless defined?(Base64)
+require 'digest' unless defined?(Digest)
 
 require 'busser/thor'
 

--- a/lib/busser/command/plugin_install.rb
+++ b/lib/busser/command/plugin_install.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'openssl'
+require 'openssl' unless defined?(OpenSSL)
 
 require 'busser/rubygems'
 require 'busser/thor'

--- a/lib/busser/cucumber.rb
+++ b/lib/busser/cucumber.rb
@@ -6,8 +6,8 @@ end
 
 require 'busser/cucumber/hooks'
 
-require 'tmpdir'
-require 'pathname'
+require 'tmpdir' unless defined?(Dir.mktmpdir)
+require 'pathname' unless defined?(Pathname)
 
 Given(/^a BUSSER_ROOT of "(.*?)"$/) do |busser_root|
   backup_envvar('BUSSER_ROOT')

--- a/lib/busser/helpers.rb
+++ b/lib/busser/helpers.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'pathname'
+require 'pathname' unless defined?(Pathname)
 
 require 'busser/rubygems'
 

--- a/lib/busser/thor.rb
+++ b/lib/busser/thor.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'thor'
+require 'thor' unless defined?(Thor)
 
 require 'busser/helpers'
 require 'busser/ui'


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>