### PR TITLE
Fix typos

### DIFF
--- a/features/plugin_install_command.feature
+++ b/features/plugin_install_command.feature
@@ -20,7 +20,7 @@ Feature: Plugin install command
     And the exit status should be 0
     And a gem named "busser-bash" is installed with version "0.1.0"
 
-  Scenario: Installing a specfic newer version of an existing plugin
+  Scenario: Installing a specific newer version of an existing plugin
     When I successfully run `busser plugin install busser-bash@0.1.0`
     And I run `busser plugin install busser-bash@0.1.1`
     Then the output should contain "Plugin bash installed (version 0.1.1)"

--- a/lib/busser/helpers.rb
+++ b/lib/busser/helpers.rb
@@ -48,7 +48,7 @@ module Busser
 
     def chef_apply(config = {}, &block)
       warn "Apologies, but Busser no longer supports the chef_apply helper," +
-        " so the contents of this block will not be exectued. Please refactor" +
+        " so the contents of this block will not be executed. Please refactor" +
         " your code to use Thor actions, shell out commands or another" +
         " strategy"
     end

--- a/spec/busser/ui_spec.rb
+++ b/spec/busser/ui_spec.rb
@@ -42,7 +42,7 @@ class SneakyUI
   end
 end
 
-# Stub that mimicks a Process::Status object
+# Stub that mimics a Process::Status object
 class FakeStatus
 
   attr_reader :exitstatus


### PR DESCRIPTION
Fixes spelling mistakes found with the [`typos`](https://github.com/crate-ci/typos) linter.

Changes are limited to comments, documentation, and test descriptions -- no functional changes.

Files touched:
- features/plugin_install_command.feature
- lib/busser/helpers.rb
- spec/busser/ui_spec.rb