### PR TITLE
Harden the CI workflow and settle on one dependency bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+---
+name: "Test"
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# The default token is granted write access to most of the repository.
+# Nothing here needs more than the checkout.
+permissions:
+  contents: read
+
+# Supersede in-flight runs for a branch. Pull requests cancel freely, but
+# pushes to main do not: every commit on main should keep a build of its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint-unit:
+    # Pinned to a commit rather than @main so an upstream edit cannot reach
+    # this repository's CI without a reviewed pull request. The trailing
+    # comment names the release the commit belongs to, which is what lets
+    # Renovate track the pin by version and keep both in step.
+    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@dab48f5187b2f34974aa1dc651d2bbd16871cad4  # v0.3.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,0 @@
----
-name: "Test"
-
-"on":
-  pull_request:
-
-jobs:
-  lint-unit:
-    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@main

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
The `Test` workflow was eight lines that delegated everything to the shared `test-kitchen/.github` reusable workflow and set nothing else. That left a few gaps worth closing.

## What was wrong

| Gap | Effect |
| --- | --- |
| `pull_request` only | No build has *ever* run against `main`, so branch protection has no green status to require. |
| Called at `@main` | An upstream edit reaches this repo's CI with no review here. |
| No `permissions:` | The default token got `contents: write`, `pull-requests: write`, `packages: write` for a job that only checks out code. |
| No `concurrency:` | Superseded runs keep burning minutes. |
| Two dependency bots | Dependabot **and** Renovate were both configured, opening the same PRs twice — #58/#57 duplicate #56/#55. |
| `lint.yml` named `Test` | Filename never matched its contents. |

## Changes

- **`lint.yml` → `ci.yml`**, now triggering on `push: [main]`, `pull_request`, and `workflow_dispatch`.
- **`permissions: contents: read`** — least privilege.
- **`concurrency`** with `cancel-in-progress` limited to pull requests. Pushes to `main` are deliberately *not* cancelled, so every commit on `main` keeps a build of its own.
- **Pinned the reusable workflow to the commit released as `v0.3.0`**, annotated so Renovate tracks it by version.
- **Dropped `.github/dependabot.yml`**, kept Renovate, and added `helpers:pinGitHubActionDigests` so it maintains the new pin.

## On the pin

Worth recording, because it nearly went the other way: at the time I wrote this the newest tag on `test-kitchen/.github` was `v0.2.4`, which trailed that repo's `main` by six commits and still tested only Ruby 3.2–3.4 on `checkout@v5`. Pinning to the newest *tag* would have silently cut this gem's matrix from five Rubies to three, undoing part of #54.

`v0.3.0` has since been released and points at exactly the commit already running here, so the pin lands on a real release with the full Ruby 3.1–4.0 matrix intact and no behaviour change.

## Verification

`yamllint --strict` clean across the repo and `actionlint` clean on the new workflow. No Ruby code touched.

## Follow-ups (not in this PR)

- #44 and #49 are stale bot PRs against dependency constraints that no longer exist after #54, and can be closed.
- One of #57/#58 (Dependabot) or #55/#56 (Renovate) is now redundant for cucumber 11 and minitest 6; the Dependabot pair will stop being refreshed once this merges.
- `unbundlerize` in `lib/busser/cucumber/hooks.rb` still carries the pre-#54 bundler variable list. It is unused, but would reintroduce the sandbox bug if called.