### PR TITLE
Move the specs to the _() expectation syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,11 @@ group :cookstyle do
 end
 
 group :test do
-  gem "minitest", "~> 5.0" # specs use the pre-6.0 must_* expectation syntax
+  # minitest 6 and cucumber 11 both require Ruby 3.2, and this gem still
+  # supports 3.1. The specs themselves no longer hold these back: they use the
+  # _() expectation syntax and pass on minitest 6 and cucumber 11 today. Unpin
+  # once the supported Ruby floor moves.
+  gem "minitest", "~> 5.0"
   gem "base64" # cucumber 9.x needs it; not a default gem on Ruby 4.0
   gem "cucumber", "~> 9.0"
   gem "rake"

--- a/busser.gemspec
+++ b/busser.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64"
 
   spec.add_development_dependency "aruba", ">= 2.0"
-  spec.add_development_dependency "fakefs"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "rake"

--- a/lib/busser/cucumber/hooks.rb
+++ b/lib/busser/cucumber/hooks.rb
@@ -21,16 +21,3 @@ end
 def restore_envvar(key)
   ENV[key] = ENV.delete("_CUKE_#{key}")
 end
-
-def unbundlerize
-  keys = %w{BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE RUBYOPT}
-
-  keys.each do |key|
-    backup_envvar(key)
-    ENV.delete(key)
-    # aruba 2.x runs commands with its own environment, so clear it there too
-    delete_environment_variable(key) if respond_to?(:delete_environment_variable)
-  end
-  yield
-  keys.each { |key| restore_envvar(key) }
-end

--- a/spec/busser/helpers_spec.rb
+++ b/spec/busser/helpers_spec.rb
@@ -9,17 +9,17 @@ describe Busser::Helpers do
   describe ".suite_path" do
 
     it "returns a Pathname" do
-      suite_path.must_be_kind_of Pathname
+      _(suite_path).must_be_kind_of Pathname
     end
 
     describe "with a default root path" do
 
       it "returns a base path if no suite name is given" do
-        suite_path.to_s.must_match %r{/opt/busser/suites$}
+        _(suite_path.to_s).must_match %r{/opt/busser/suites$}
       end
 
       it "returns a suite path given a suite name" do
-        suite_path("fuzzy").to_s.must_match %r{/opt/busser/suites/fuzzy$}
+        _(suite_path("fuzzy").to_s).must_match %r{/opt/busser/suites/fuzzy$}
       end
     end
 
@@ -30,12 +30,12 @@ describe Busser::Helpers do
 
       it "returns a base path if no suite name is given" do
         ENV['BUSSER_ROOT'] = "/path/to/busser"
-        suite_path.to_s.must_match %r{/path/to/busser/suites$}
+        _(suite_path.to_s).must_match %r{/path/to/busser/suites$}
       end
 
       it "returns a suite path given a suite name" do
         ENV['BUSSER_ROOT'] = "/path/to/busser"
-        suite_path("fuzzy").to_s.must_match %r{/path/to/busser/suites/fuzzy$}
+        _(suite_path("fuzzy").to_s).must_match %r{/path/to/busser/suites/fuzzy$}
       end
     end
   end
@@ -43,17 +43,17 @@ describe Busser::Helpers do
   describe ".vendor_path" do
 
     it "returns a Pathname" do
-      vendor_path.must_be_kind_of Pathname
+      _(vendor_path).must_be_kind_of Pathname
     end
 
     describe "with a default root path" do
 
       it "returns a base path if no product name is given" do
-        vendor_path.to_s.must_match %r{/opt/busser/vendor$}
+        _(vendor_path.to_s).must_match %r{/opt/busser/vendor$}
       end
 
       it "returns a vendor path given a product name" do
-        vendor_path("supreme").to_s.must_match %r{/opt/busser/vendor/supreme$}
+        _(vendor_path("supreme").to_s).must_match %r{/opt/busser/vendor/supreme$}
       end
     end
 
@@ -64,12 +64,12 @@ describe Busser::Helpers do
 
       it "returns a base path if no product name is given" do
         ENV['BUSSER_ROOT'] = "/path/to/busser"
-        vendor_path.to_s.must_match %r{/path/to/busser/vendor$}
+        _(vendor_path.to_s).must_match %r{/path/to/busser/vendor$}
       end
 
       it "returns a suite path given a product name" do
         ENV['BUSSER_ROOT'] = "/path/to/busser"
-        vendor_path("maximal").to_s.must_match \
+        _(vendor_path("maximal").to_s).must_match \
           %r{/path/to/busser/vendor/maximal$}
       end
     end

--- a/spec/busser/ui_spec.rb
+++ b/spec/busser/ui_spec.rb
@@ -65,35 +65,35 @@ describe Busser::UI do
   end
 
   it "#banner should display a formatted message" do
-    ui.invoke_banner("coffee").must_equal "-----> coffee"
+    _(ui.invoke_banner("coffee")).must_equal "-----> coffee"
   end
 
   it "#info should display a formatted message" do
-    ui.invoke_info("beans").must_equal "       beans"
+    _(ui.invoke_info("beans")).must_equal "       beans"
   end
 
   it "#warn should display a formatted message" do
-    ui.invoke_warn("grinder").must_equal ">>>>>> grinder"
+    _(ui.invoke_warn("grinder")).must_equal ">>>>>> grinder"
   end
 
   it "#fatal should display a formatted message on stderr" do
-    capture_stderr { ui.invoke_fatal("grinder") }.must_equal "!!!!!! grinder\n"
+    _(capture_stderr { ui.invoke_fatal("grinder") }).must_equal "!!!!!! grinder\n"
   end
 
   describe "#die" do
     it "prints a message to stderr" do
-      capture_stderr { ui.invoke_die("noes") }.must_equal "!!!!!! noes\n"
+      _(capture_stderr { ui.invoke_die("noes") }).must_equal "!!!!!! noes\n"
     end
 
     it "calls exit with 1 by default" do
       capture_stderr do
-        ui.invoke_die("fail").must_equal 1
+        _(ui.invoke_die("fail")).must_equal 1
       end
     end
 
     it "exits with a custom exit status" do
       capture_stderr do
-        ui.invoke_die("fail", 16).must_equal 16
+        _(ui.invoke_die("fail", 16)).must_equal 16
       end
     end
   end
@@ -103,45 +103,48 @@ describe Busser::UI do
     it "calls #run with correct options" do
       ui.invoke_run!("doitpls")
 
-      ui.run_args.must_equal([
+      _(ui.run_args).must_equal([
         "doitpls",
         { :capture => false, :verbose => false}
       ])
     end
 
     it "returns true if command succeeded" do
-      ui.invoke_run!("great-stuff").must_equal true
+      _(ui.invoke_run!("great-stuff")).must_equal true
     end
 
     it "re-raises any exceptions from the underlying fork/exec" do
       ui.stubs(:run).raises(Errno::ENOMEM)
 
-      capture_stderr {
-        proc { ui.invoke_run!("failwhale") }.must_raise Errno::ENOMEM
-      }.must_match /raised an exception/
+      output = capture_stderr do
+        _ { ui.invoke_run!("failwhale") }.must_raise Errno::ENOMEM
+      end
+
+      _(output).must_match(/raised an exception/)
     end
 
     it "terminates the program if the command failed" do
       ui.status = FakeStatus.new(false)
       capture_stderr { ui.invoke_run!("failwhale") }
 
-      ui.died?.must_equal true
+      _(ui.died?).must_equal true
     end
 
     it "terminates with the exit code of the failed command" do
       ui.status = FakeStatus.new(false, 24)
 
       capture_stderr do
-        ui.invoke_run!("failwhale").must_equal 24
+        _(ui.invoke_run!("failwhale")).must_equal 24
       end
     end
 
     it "terminates the program if status is nil" do
       ui.status = nil
-      capture_stderr { ui.invoke_run!("failwhale") }.
-        must_match /did not return a valid status/
+      output = capture_stderr { ui.invoke_run!("failwhale") }
 
-      ui.died?.must_equal true
+      _(output).must_match(/did not return a valid status/)
+
+      _(ui.died?).must_equal true
     end
   end
 
@@ -150,7 +153,7 @@ describe Busser::UI do
     it "calls #run_ruby_script with correct default options" do
       ui.invoke_run_ruby_script!("theworks.rb")
 
-      ui.run_ruby_script_args.must_equal([
+      _(ui.run_ruby_script_args).must_equal([
         "theworks.rb",
         { :capture => false, :verbose => false }
       ])
@@ -159,45 +162,48 @@ describe Busser::UI do
     it "calls #run_ruby_script with correct default options" do
       ui.invoke_run_ruby_script!("theworks.rb", :verbose => true)
 
-      ui.run_ruby_script_args.must_equal([
+      _(ui.run_ruby_script_args).must_equal([
         "theworks.rb",
         { :capture => false, :verbose => true }
       ])
     end
 
     it "returns true if command succeeded" do
-      ui.invoke_run_ruby_script!("thewin.rb").must_equal true
+      _(ui.invoke_run_ruby_script!("thewin.rb")).must_equal true
     end
 
     it "re-raises any exceptions from the underlying fork/exec" do
       ui.stubs(:run_ruby_script).raises(Errno::ENOMEM)
 
-      capture_stderr {
-        proc { ui.invoke_run_ruby_script!("nope.rb") }.must_raise Errno::ENOMEM
-      }.must_match /raised an exception/
+      output = capture_stderr do
+        _ { ui.invoke_run_ruby_script!("nope.rb") }.must_raise Errno::ENOMEM
+      end
+
+      _(output).must_match(/raised an exception/)
     end
 
     it "terminates the program if the script failed" do
       ui.status = FakeStatus.new(false)
       capture_stderr { ui.invoke_run_ruby_script!("nope.rb") }
 
-      ui.died?.must_equal true
+      _(ui.died?).must_equal true
     end
 
     it "terminates with the exit code of the failed script" do
       ui.status = FakeStatus.new(false, 97)
 
       capture_stderr do
-        ui.invoke_run_ruby_script!("nadda.rb").must_equal 97
+        _(ui.invoke_run_ruby_script!("nadda.rb")).must_equal 97
       end
     end
 
     it "terminates the program if status is nil" do
       ui.status = nil
-      capture_stderr { ui.invoke_run_ruby_script!("nope.rb") }.
-        must_match /did not return a valid status/
+      output = capture_stderr { ui.invoke_run_ruby_script!("nope.rb") }
 
-      ui.died?.must_equal true
+      _(output).must_match(/did not return a valid status/)
+
+      _(ui.died?).must_equal true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'fakefs/safe'
 require 'minitest/autorun'
 require 'mocha/minitest'


### PR DESCRIPTION
Minitest 6 removes the global `must_*` / `wont_*` expectations. All 32 in this suite used them, emitting deprecation warnings on every run and failing outright under 6 — which is why both dependency bots have minitest 6 PRs (#56, #58) failing on **all five Rubies**.

## Changes

- **32 expectations wrapped in `_()`.** Two sat on the receiver of a multi-line `capture_stderr` block and two more used a trailing-dot line continuation; those bind the captured output to a local first, which reads better than wrapping a block. Block expectations become `_ { ... }` rather than `proc { ... }`.
- **Dropped `fakefs`** — required in `spec_helper.rb` and declared in the gemspec, but not used by a single spec.
- **Removed `unbundlerize`** from the cucumber hooks. Unreferenced, and it still carried the pre-#54 bundler variable list, so it would have reintroduced the `GEM_HOME` sandbox bug the moment anything called it.
- **Corrected the `Gemfile` pin comment**, which claimed the specs needed pre-6.0 syntax. They no longer do.

## Pins deliberately unchanged

`_(foo).must_equal bar` is valid on minitest **5 and 6**, so this lands without moving any pin and CI keeps running the full Ruby 3.1–4.0 matrix. Nothing goes red.

Raising the floor is a separate change on purpose: minitest 6, cucumber 11 and fakefs 3 all require **Ruby >= 3.2**, but the shared `test-kitchen/.github` workflow hardcodes `ruby: ["3.1", ..., "4.0"]` and accepts no matrix input. Setting `required_ruby_version = ">= 3.2"` today would make the Ruby 3.1 job fail forever. That needs an upstream `ruby_versions` input first.

## Verification

Against the shipped pins (minitest 5 / cucumber 9): **30 runs, 46 assertions, 0 failures**, **0 deprecation warnings** (was 32), 16 scenarios / 99 steps passing, cookstyle clean.

Then in a scratch bundle forced to **minitest 6.0.6 + cucumber 11.1.1** — the versions the bot PRs want:

```
30 runs, 46 assertions, 0 failures, 0 errors, 0 skips
16 scenarios (16 passed)
99 steps (99 passed)
```

So the follow-up that raises the floor and unpins should be mechanical.

## Relationship to #50

#50 (@damacus, 2022) contains the same `_()` migration and deserves the credit for spotting it first. Its other changes have been overtaken: it sets `required_ruby_version = ">= 2.7"`, adds a unit workflow with matrix `['2.7', '3.0', '3.1']`, and re-adds a `publish.yaml` duplicating the org shared workflow, while `.travis.yml` and `.cane` were already removed in #54. I have left #50 open rather than closing a maintainer's PR.

## Follow-ups

1. Upstream PR to `test-kitchen/.github` adding a `ruby_versions` input to `lint-unit.yml`.
2. Then here: `required_ruby_version >= 3.2`, unpin minitest and cucumber, pass `3.2, 3.3, 3.4, 4.0`.
3. Stale bot PRs #44 and #49 target constraints that no longer exist post-#54 and can be closed.