### PR TITLE
Require Ruby 3.2 and take the current test tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,9 @@ jobs:
     # this repository's CI without a reviewed pull request. The trailing
     # comment names the release the commit belongs to, which is what lets
     # Renovate track the pin by version and keep both in step.
-    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@dab48f5187b2f34974aa1dc651d2bbd16871cad4  # v0.3.0
+    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@95ef7803cf23aae5ee68593de5b7e0a731c1a929  # v0.4.0
+    with:
+      # This gem requires Ruby 3.2, and so do minitest 6 and cucumber 11.
+      # Without this the shared workflow would still start a Ruby 3.1 job and
+      # bundler would refuse to resolve there.
+      ruby_versions: '["3.2", "3.3", "3.4", "4.0"]'

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,8 @@ group :cookstyle do
 end
 
 group :test do
-  # minitest 6 and cucumber 11 both require Ruby 3.2, and this gem still
-  # supports 3.1. The specs themselves no longer hold these back: they use the
-  # _() expectation syntax and pass on minitest 6 and cucumber 11 today. Unpin
-  # once the supported Ruby floor moves.
-  gem "minitest", "~> 5.0"
-  gem "base64" # cucumber 9.x needs it; not a default gem on Ruby 4.0
-  gem "cucumber", "~> 9.0"
+  gem "minitest", ">= 6.0"
+  gem "base64" # cucumber needs it; not a default gem on Ruby 4.0
+  gem "cucumber", ">= 11.1"
   gem "rake"
 end

--- a/busser.gemspec
+++ b/busser.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   # thor 1.1.0 references DidYouMean::SPELL_CHECKERS, removed in Ruby 3.1,
   # so the CLI crashed on startup on every supported Ruby


### PR DESCRIPTION
Completes the sequence started in #60. That PR moved the specs to the `_()` expectation syntax without touching a pin; this one raises the floor and takes the modern tooling.

## Why the floor has to move

minitest 6, cucumber 11 and fakefs 3 **all require Ruby >= 3.2**. Supporting 3.1 meant pinning the whole test stack to versions that still run on it. Ruby 3.1 reached end of life on 2025-03-26.

## Changes

- `busser.gemspec`: `required_ruby_version = ">= 3.2"`
- `Gemfile`: dropped the upper bounds on minitest and cucumber, keeping lower bounds at the versions verified here — `minitest >= 6.0`, `cucumber >= 11.1`. Resolves **minitest 6.0.6** and **cucumber 11.1.1**.
- `.github/workflows/ci.yml`: passes `ruby_versions: '["3.2", "3.3", "3.4", "4.0"]'` and moves the pin to `v0.4.0`.

Nothing in `spec/` changes — #60 already did that work, which is what made this PR small.

## The CI input

Without `ruby_versions` the shared workflow would still start a Ruby 3.1 job and bundler would refuse to resolve against the new gemspec, leaving this repo permanently red. The input landed in `test-kitchen/.github` [v0.4.0](https://github.com/test-kitchen/.github/releases/tag/v0.4.0) (test-kitchen/.github#42), so the pin moves to that release in the same change.

## Verification

Locally against the newly resolved stack:

```
minitest 6.0.6 / cucumber 11.1.1 / aruba 2.4.1
30 runs, 46 assertions, 0 failures, 0 errors, 0 skips   (0 deprecation warnings)
16 scenarios (16 passed)
99 steps (99 passed)
cookstyle: 27 files inspected, no offenses detected
yamllint --strict: clean
actionlint: clean
```

## Supersedes

#55, #56, #57 and #58 all ask for exactly these two bumps and can be closed once this merges. #44 and #49 target constraints that no longer exist after #54.

## One thing to decide separately

**Ruby 3.2 reached end of life on 2026-03-31**, so this floor lands on a version that is already EOL — only 3.3, 3.4 and 4.0 are still supported. I stopped at 3.2 because nothing in the dependency set requires more, and raising a public gem's floor is a consumer-facing decision rather than a mechanical one. Going to `>= 3.3` later is a two-line change: the gemspec and the `ruby_versions` list.