### PR TITLE
fix: stop running a plugin twice and writing unverified files

### DIFF
--- a/features/deserialize_command.feature
+++ b/features/deserialize_command.feature
@@ -16,4 +16,7 @@ Feature: Deserialize command
   Scenario: Mismatching MD5 sum fails command
     When I run `bash -c "cat ../../features/files/base64.txt | busser deserialize --destination=decoded.txt --md5sum=nope --perms=0755"`
     Then the output should contain "does not match source file"
-    Then the exit status should not be 0
+    And the exit status should not be 0
+    # The digest was once checked only after the write, so the command failed
+    # while still leaving the unverified file on disk.
+    And the file "decoded.txt" should not exist

--- a/lib/busser/command/deserialize.rb
+++ b/lib/busser/command/deserialize.rb
@@ -42,13 +42,17 @@ module Busser
         file = File.expand_path(options[:destination])
         contents = Base64.decode64(STDIN.read)
 
-        FileUtils.mkdir_p(File.dirname(file))
-        File.open(file, "wb") { |f| f.write(contents) }
-        FileUtils.chmod(Integer(options[:perms]), file)
-
+        # Verify before writing. Checking afterwards still failed the command,
+        # but only once the unverified content was already on disk with its
+        # requested permissions, so a truncated stream left an executable file
+        # behind for anything later to pick up.
         if Digest::MD5.hexdigest(contents) != options[:md5sum]
           abort "Streamed file #{file} does not match source file md5"
         end
+
+        FileUtils.mkdir_p(File.dirname(file))
+        File.open(file, "wb") { |f| f.write(contents) }
+        FileUtils.chmod(Integer(options[:perms]), file)
       end
     end
   end

--- a/lib/busser/plugin.rb
+++ b/lib/busser/plugin.rb
@@ -34,16 +34,22 @@ module Busser
 
     def runner_plugins(plugin_names = nil)
       if plugin_names
-        Array(plugin_names).map { |plugin| runner_plugin(plugin) }
+        Array(plugin_names).map { |plugin| runner_plugin(plugin) }.uniq
       else
         all_runner_plugins
       end
     end
 
+    # Gem.find_files searches every installed gem version, not just the
+    # newest, so a machine holding two versions of a plugin gem reports that
+    # plugin twice. Callers treat each entry as one suite to run, so the
+    # duplicates made `busser test` run a suite twice and `busser plugin list`
+    # print it twice. The path is what gets required, and require resolves to
+    # the active version, so collapsing the repeats is safe.
     def all_runner_plugins
       Gem.find_files("busser/runner_plugin/*.rb").map do |file|
         "busser/runner_plugin/#{File.basename(file).sub(/\.rb$/, "")}"
-      end
+      end.uniq
     end
 
     def require!(plugin_path)

--- a/spec/busser/command/deserialize_spec.rb
+++ b/spec/busser/command/deserialize_spec.rb
@@ -1,0 +1,110 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "base64"
+require "digest/md5"
+require "tmpdir"
+
+require "busser/command/deserialize"
+
+# Deserialize is how Test Kitchen streams a file onto the instance under test,
+# so the thing worth pinning down is what ends up on disk.
+describe Busser::Command::Deserialize do
+
+  CONTENTS = "Hello there.\n".freeze
+
+  before do
+    @tmpdir = Dir.mktmpdir("busser-deserialize")
+    @file = File.join(@tmpdir, "nested", "decoded.txt")
+  end
+
+  after do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  describe "with a matching digest" do
+
+    it "writes the decoded contents" do
+      deserialize(md5sum: Digest::MD5.hexdigest(CONTENTS))
+
+      _(File.read(@file)).must_equal CONTENTS
+    end
+
+    it "creates any missing parent directories" do
+      deserialize(md5sum: Digest::MD5.hexdigest(CONTENTS))
+
+      _(File.directory?(File.dirname(@file))).must_equal true
+    end
+
+    it "applies the requested permissions" do
+      deserialize(md5sum: Digest::MD5.hexdigest(CONTENTS), perms: "0755")
+
+      _(format("%o", File.stat(@file).mode & 0o777)).must_equal "755"
+    end
+
+    it "writes binary content unchanged" do
+      binary = "\x00\x01\x02\xFF".dup.force_encoding("ASCII-8BIT")
+
+      deserialize(contents: binary, md5sum: Digest::MD5.hexdigest(binary))
+
+      _(File.binread(@file)).must_equal binary
+    end
+  end
+
+  describe "with a mismatching digest" do
+
+    it "fails the command" do
+      _ { deserialize(md5sum: "not-the-right-digest") }.must_raise SystemExit
+    end
+
+    # The digest used to be checked only after the write, so a corrupted or
+    # truncated stream still landed on disk, with its requested permissions,
+    # for a later command to pick up and run.
+    it "leaves no file behind" do
+      _ { deserialize(md5sum: "not-the-right-digest") }.must_raise SystemExit
+
+      _(File.exist?(@file)).must_equal false
+    end
+
+    it "does not overwrite a file that is already there" do
+      FileUtils.mkdir_p(File.dirname(@file))
+      File.write(@file, "original contents")
+
+      _ { deserialize(md5sum: "not-the-right-digest") }.must_raise SystemExit
+
+      _(File.read(@file)).must_equal "original contents"
+    end
+  end
+
+  def deserialize(md5sum:, contents: CONTENTS, perms: "0644")
+    STDIN.stubs(:read).returns(Base64.encode64(contents))
+
+    command = Busser::Command::Deserialize.new([], {
+      "destination" => @file,
+      "md5sum" => md5sum,
+      "perms" => perms,
+    })
+    capture_stderr { command.perform }
+  end
+
+  def capture_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stderr = original
+  end
+end

--- a/spec/busser/plugin_spec.rb
+++ b/spec/busser/plugin_spec.rb
@@ -1,0 +1,133 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../spec_helper"
+
+require "busser/plugin"
+require "busser/ui"
+
+describe Busser::Plugin do
+
+  describe ".runner_plugin" do
+
+    it "builds the require path for a plugin name" do
+      _(Busser::Plugin.runner_plugin("bash"))
+        .must_equal "busser/runner_plugin/bash"
+    end
+  end
+
+  describe ".runner_plugins" do
+
+    it "maps each given name to its require path" do
+      _(Busser::Plugin.runner_plugins(%w{bash minitest})).must_equal [
+        "busser/runner_plugin/bash",
+        "busser/runner_plugin/minitest",
+      ]
+    end
+
+    it "accepts a single name that is not in an array" do
+      _(Busser::Plugin.runner_plugins("bash"))
+        .must_equal ["busser/runner_plugin/bash"]
+    end
+
+    # Callers run one suite per entry, so a repeated name would run that
+    # suite twice.
+    it "returns a name given more than once only once" do
+      _(Busser::Plugin.runner_plugins(%w{bash bash}))
+        .must_equal ["busser/runner_plugin/bash"]
+    end
+
+    it "falls back to every installed plugin when given no names" do
+      Busser::Plugin.expects(:all_runner_plugins).returns(["stubbed"])
+
+      _(Busser::Plugin.runner_plugins).must_equal ["stubbed"]
+    end
+  end
+
+  describe ".all_runner_plugins" do
+
+    it "turns each found file into a require path" do
+      stub_found_files %w{
+        /gems/busser-bash-0.1.1/lib/busser/runner_plugin/bash.rb
+        /gems/busser-serverspec-0.5.0/lib/busser/runner_plugin/serverspec.rb
+      }
+
+      _(Busser::Plugin.all_runner_plugins).must_equal [
+        "busser/runner_plugin/bash",
+        "busser/runner_plugin/serverspec",
+      ]
+    end
+
+    # Gem.find_files searches every installed version of every gem. A machine
+    # that has installed a plugin more than once therefore reports it once per
+    # version, which made `busser test` run that suite repeatedly and
+    # `busser plugin list` print it repeatedly.
+    it "reports a plugin once when several versions of its gem are installed" do
+      stub_found_files %w{
+        /gems/busser-bash-0.1.1/lib/busser/runner_plugin/bash.rb
+        /gems/busser-bash-0.1.0/lib/busser/runner_plugin/bash.rb
+      }
+
+      _(Busser::Plugin.all_runner_plugins)
+        .must_equal ["busser/runner_plugin/bash"]
+    end
+
+    it "keeps the first occurrence, which is the newest version found" do
+      stub_found_files %w{
+        /gems/busser-bash-0.1.1/lib/busser/runner_plugin/bash.rb
+        /gems/busser-bash-0.1.0/lib/busser/runner_plugin/bash.rb
+        /gems/busser-serverspec-0.5.0/lib/busser/runner_plugin/serverspec.rb
+      }
+
+      _(Busser::Plugin.all_runner_plugins).must_equal [
+        "busser/runner_plugin/bash",
+        "busser/runner_plugin/serverspec",
+      ]
+    end
+
+    it "returns nothing when no plugins are installed" do
+      stub_found_files []
+
+      _(Busser::Plugin.all_runner_plugins).must_equal []
+    end
+
+    def stub_found_files(files)
+      Gem.expects(:find_files)
+        .with("busser/runner_plugin/*.rb")
+        .returns(files)
+    end
+  end
+
+  describe ".require!" do
+
+    it "requires the given path" do
+      Busser::Plugin.expects(:require).with("busser/runner_plugin/bash")
+
+      Busser::Plugin.require!("busser/runner_plugin/bash")
+    end
+
+    # A plugin gem that is listed but not loadable is a common failure on a
+    # test instance, and the message is the only clue the user gets.
+    it "dies with the offending path when the plugin cannot be loaded" do
+      Busser::Plugin.stubs(:require).raises(LoadError, "no such file")
+      Busser::UI.expects(:die).with do |message|
+        message.include?("busser/runner_plugin/nope") &&
+          message.include?("LoadError") &&
+          message.include?("no such file")
+      end
+
+      Busser::Plugin.require!("busser/runner_plugin/nope")
+    end
+  end
+end


### PR DESCRIPTION
You asked for tests that catch real bugs rather than tests for coverage. I went looking in the library code that had none — `lib/busser/plugin.rb` and the ten command classes — and found **two real bugs**. Both are fixed here, each with a regression test that fails without the fix.

## Bug 1 — a plugin installed twice runs twice

`Gem.find_files` searches `Gem::Specification.stubs`, which is **every installed version**, not just the newest. `all_runner_plugins` mapped those files to plugin names, so one plugin with two installed gem versions produced two identical entries. Callers treat each entry as one suite to run.

Reproduced with `busser-bash` 0.1.0 and 0.1.1 in one `GEM_HOME`:

```
$ busser plugin list          $ busser test
Plugin  Version               -----> Running bash test suite
dummy   0.8.0                 -----> Running bash test suite     # twice
bash    0.1.1
bash    0.1.1                 # note: both rows say 0.1.1
```

This matters because test instances accumulate plugin versions — every `busser plugin install` that resolves to a newer version leaves the old one installed. The symptom is a suite silently running twice on `kitchen verify`, and a plugin list that reports the same version twice rather than the two it actually has.

**Fix:** collapse the repeats. The entry is a require path and `require` resolves to the active version, so nothing else changes. Repeated names passed on the command line (`busser test bash bash`) collapse the same way.

## Bug 2 — a failed transfer still leaves the file on disk

`busser deserialize` checked the md5 digest **after** writing the file and applying its permissions:

```ruby
File.open(file, "wb") { |f| f.write(contents) }
FileUtils.chmod(Integer(options[:perms]), file)

if Digest::MD5.hexdigest(contents) != options[:md5sum]   # too late
  abort "..."
end
```

The command failed correctly, but the unverified content was already on disk with its requested mode:

```
$ echo -n "hello world" | base64 | busser deserialize --destination payload.sh \
    --md5sum totally-wrong-md5 --perms 0755
Streamed file .../payload.sh does not match source file md5

$ ls -l payload.sh
-rwxr-xr-x  1 ...  11 payload.sh      # still there, still executable
```

This is the command Test Kitchen uses to stream files onto the instance under test over SSH, so a truncated transfer left an executable artifact behind that outlived the failure meant to prevent it.

**Fix:** verify before writing.

## The existing test did not catch it

The cucumber scenario for a digest mismatch asserted only the output message and a non-zero exit status — never that the file was absent — so it passed for as long as the bug existed. That scenario now also asserts the file is gone. Worth calling out as the exact shape of a test that looks like coverage but checks nothing that matters.

## New unit specs

`spec/busser/plugin_spec.rb` and `spec/busser/command/deserialize_spec.rb`, chosen for behaviour that can actually break:

- multiple installed versions collapse to one plugin (Bug 1)
- a repeated command-line name runs once
- `require!` dies with the offending path and the underlying error — the only clue a user gets when a plugin gem is listed but not loadable on an instance
- a mismatching digest leaves **no** file behind (Bug 2)
- a mismatching digest does not overwrite a file already at that path
- binary content round-trips unchanged, and permissions are applied

I deliberately did **not** add tests for things like `runner_plugin` string interpolation beyond one case — they cannot realistically break and would just be coverage.

## Verification

The point of a regression test is that it fails on the old code. With both fixes reverted:

```
48 runs, 69 assertions, 5 failures, 0 errors, 0 skips
```

With the fixes:

```
48 runs, 71 assertions, 0 failures, 0 errors, 0 skips    (was 30 runs, 46 assertions)
16 scenarios (16 passed), 100 steps (100 passed)
cookstyle: 27 files inspected, no offenses detected
```

Both fixes also confirmed end to end against the original reproductions: `plugin list` now prints `bash` once, `busser test` runs the suite once, and the corrupt transfer leaves zero files behind.

## Considered and rejected

`suite_path("/etc/passwd")` returns `/etc/passwd`, and `suite_path("../../etc")` escapes the root, because `Pathname#+` lets an absolute or traversing argument replace the base. I traced every caller: `suite cleanup` calls `suite_path` with no argument, and `Test#prepare_suite` passes a `File.basename` result, so nothing destructive takes user input. Only `busser suite path` does, and it just prints. Real hardening, but speculative rather than a bug, so I left it out rather than pad this PR.