### PR TITLE
fix: report signals and keep bundler out of the busser binstub

### DIFF
--- a/lib/busser/command/setup.rb
+++ b/lib/busser/command/setup.rb
@@ -79,9 +79,19 @@ module Busser
             SET "GEM_PATH=#{gem_path}"
             SET "GEM_CACHE=#{gem_home}\\cache"
 
-            REM Unset RUBYOPT, we don't want this bleeding into our runtime.
+            REM Keep the calling Ruby environment out of this one. Clearing
+            REM RUBYOPT is no longer enough: RubyGems requires bundler/setup
+            REM whenever BUNDLER_SETUP is set, and bundler then points GEM_HOME
+            REM at the calling project's bundle, undoing the isolation above.
             SET RUBYOPT=
             SET GEMRC=
+            SET RUBYLIB=
+            SET BUNDLER_SETUP=
+            SET BUNDLER_VERSION=
+            SET BUNDLE_BIN_PATH=
+            SET BUNDLE_GEMFILE=
+            SET BUNDLE_LOCKFILE=
+            SET BUNDLE_PATH=
 
             REM Call the actual Busser bin with our arguments
             "#{ruby_bin}" "#{gem_bindir}\\busser" %*
@@ -120,8 +130,12 @@ module Busser
             GEM_PATH="#{gem_path}"; export GEM_PATH
             GEM_CACHE="#{gem_home}/cache"; export GEM_CACHE
 
-            # Unset RUBYOPT, we don't want this bleeding into our runtime.
-            unset RUBYOPT GEMRC
+            # Keep the calling Ruby environment out of this one. Unsetting
+            # RUBYOPT is no longer enough: RubyGems requires bundler/setup
+            # whenever BUNDLER_SETUP is set, and bundler then points GEM_HOME
+            # at the calling project's bundle, undoing the isolation above.
+            unset RUBYOPT GEMRC RUBYLIB BUNDLER_SETUP BUNDLER_VERSION
+            unset BUNDLE_BIN_PATH BUNDLE_GEMFILE BUNDLE_LOCKFILE BUNDLE_PATH
 
             # Call the actual Busser bin with our arguments
             exec "#{ruby_bin}" "#{gem_bindir}/busser" "$@"

--- a/lib/busser/ui.rb
+++ b/lib/busser/ui.rb
@@ -96,6 +96,14 @@ module Busser
         )
       elsif status.success?
         true
+      elsif status.exitstatus.nil?
+        # A process killed by a signal has no exit status, and Kernel#exit
+        # rejects nil, so reporting it as an exit code raised a TypeError and
+        # took Busser down with a stack trace rather than a diagnosis. Signals
+        # are how the out of memory killer stops a test run, which is the same
+        # situation the nil status branch above was written for.
+        signal = status.termsig
+        die("#{type} [#{cmd}] was terminated by signal #{signal}", 128 + signal)
       else
         code = status.exitstatus
         die("#{type} [#{cmd}] exit code was #{code}", code)

--- a/spec/busser/command/setup_spec.rb
+++ b/spec/busser/command/setup_spec.rb
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "tmpdir"
+
+require "busser/command/setup"
+
+# The binstub exists to give Busser an isolated gem environment on the machine
+# under test, so what it does to the environment before exec is the contract
+# worth pinning down.
+describe Busser::Command::Setup do
+
+  # Anything left set here lets the calling Ruby environment reach into
+  # Busser's. RUBYOPT was once the only way in; RubyGems now requires
+  # bundler/setup whenever BUNDLER_SETUP is present, and bundler then resets
+  # GEM_HOME to the calling project's bundle.
+  LEAKY_VARIABLES = %w{
+    RUBYOPT GEMRC RUBYLIB
+    BUNDLER_SETUP BUNDLER_VERSION
+    BUNDLE_BIN_PATH BUNDLE_GEMFILE BUNDLE_LOCKFILE BUNDLE_PATH
+  }.freeze
+
+  before do
+    @tmpdir = Dir.mktmpdir("busser-setup")
+    @original_root = ENV["BUSSER_ROOT"]
+    ENV["BUSSER_ROOT"] = @tmpdir
+  end
+
+  after do
+    ENV["BUSSER_ROOT"] = @original_root
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  describe "the bourne binstub" do
+
+    it "is created and executable" do
+      run_setup
+
+      _(File.exist?(binstub)).must_equal true
+      _(File.stat(binstub).mode & 0o111).wont_equal 0
+    end
+
+    it "pins BUSSER_ROOT and the gem paths" do
+      run_setup
+
+      _(binstub_body).must_match(/BUSSER_ROOT="#{Regexp.escape(@tmpdir)}"/)
+      _(binstub_body).must_match(/^GEM_HOME=/)
+      _(binstub_body).must_match(/^GEM_PATH=/)
+    end
+
+    LEAKY_VARIABLES.each do |name|
+      it "unsets #{name} before exec" do
+        run_setup
+
+        _(unset_variables).must_include name
+      end
+    end
+
+    it "unsets everything before handing off to ruby" do
+      run_setup
+
+      unset_line = binstub_body.index("unset ")
+      exec_line = binstub_body.index("exec ")
+
+      _(unset_line).must_be :<, exec_line
+    end
+
+    def binstub
+      File.join(@tmpdir, "bin", "busser")
+    end
+
+    def unset_variables
+      binstub_body.scan(/^unset (.+)$/).flatten.join(" ").split(/\s+/)
+    end
+  end
+
+  describe "the bat binstub" do
+
+    LEAKY_VARIABLES.each do |name|
+      it "clears #{name} before exec" do
+        run_setup(type: "bat")
+
+        _(binstub_body).must_match(/^SET #{name}=\s*$/)
+      end
+    end
+
+    def binstub
+      File.join(@tmpdir, "bin", "busser.bat")
+    end
+  end
+
+  def run_setup(type: "bourne")
+    command = Busser::Command::Setup.new([], { "type" => type })
+    capture_stdout { command.perform }
+  end
+
+  def binstub_body
+    File.read(binstub)
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+end

--- a/spec/busser/ui_spec.rb
+++ b/spec/busser/ui_spec.rb
@@ -45,10 +45,16 @@ end
 # Stub that mimics a Process::Status object
 class FakeStatus
 
-  attr_reader :exitstatus
+  attr_reader :exitstatus, :termsig
 
-  def initialize(success = true, exitstatus = 0)
-    @success, @exitstatus = success, exitstatus
+  # A process stopped by a signal reports success? as nil rather than false,
+  # carries no exitstatus, and sets termsig instead.
+  def self.signalled(termsig)
+    new(nil, nil, termsig)
+  end
+
+  def initialize(success = true, exitstatus = 0, termsig = nil)
+    @success, @exitstatus, @termsig = success, exitstatus, termsig
   end
 
   def success?
@@ -138,6 +144,26 @@ describe Busser::UI do
       end
     end
 
+    # The out of memory killer stops a run with SIGKILL. exitstatus is nil
+    # there, and reporting it as an exit code used to raise a TypeError from
+    # Kernel#exit, so Busser died with a stack trace instead of saying what
+    # happened.
+    it "reports the signal when the command was killed" do
+      ui.status = FakeStatus.signalled(9)
+      output = capture_stderr { ui.invoke_run!("failwhale") }
+
+      _(output).must_match(/terminated by signal 9/)
+      _(ui.died?).must_equal true
+    end
+
+    it "terminates with 128 plus the signal when the command was killed" do
+      ui.status = FakeStatus.signalled(9)
+
+      capture_stderr do
+        _(ui.invoke_run!("failwhale")).must_equal 137
+      end
+    end
+
     it "terminates the program if status is nil" do
       ui.status = nil
       output = capture_stderr { ui.invoke_run!("failwhale") }
@@ -194,6 +220,26 @@ describe Busser::UI do
 
       capture_stderr do
         _(ui.invoke_run_ruby_script!("nadda.rb")).must_equal 97
+      end
+    end
+
+    # The out of memory killer stops a run with SIGKILL. exitstatus is nil
+    # there, and reporting it as an exit code used to raise a TypeError from
+    # Kernel#exit, so Busser died with a stack trace instead of saying what
+    # happened.
+    it "reports the signal when the command was killed" do
+      ui.status = FakeStatus.signalled(9)
+      output = capture_stderr { ui.invoke_run_ruby_script!("nope.rb") }
+
+      _(output).must_match(/terminated by signal 9/)
+      _(ui.died?).must_equal true
+    end
+
+    it "terminates with 128 plus the signal when the command was killed" do
+      ui.status = FakeStatus.signalled(9)
+
+      capture_stderr do
+        _(ui.invoke_run_ruby_script!("nope.rb")).must_equal 137
       end
     end
 


### PR DESCRIPTION
A correctness audit of the runtime. Two confirmed bugs, both in code that had no unit tests, both reproduced before fixing.

## Bug 1 — a signal-killed command crashes Busser

`Process::Status#exitstatus` is **nil** when a process is stopped by a signal. `handle_command` read it anyway and passed it to `Kernel#exit`, which rejects nil:

```
$ # a test command killed by SIGKILL
!!!!!! Command [bundle exec rspec] exit code was
TypeError: no implicit conversion from nil to integer
```

Note the blank exit code, then a stack trace instead of a diagnosis. This lands in exactly the situation the neighbouring branch already warns about — its message reads *"This instance could be starved for RAM"*, and a SIGKILL from the OOM killer is precisely how that ends. The branch meant to explain memory exhaustion was unreachable for the most common way it happens.

Worth noting *why* it slipped through: a signalled status returns `success? == nil`, not `false`, so it fell past the `elsif status.success?` branch into the exit-code path that assumes a number.

**Fix:** report the signal and exit `128 + signum`, as a shell does.

```
!!!!!! Command [bundle exec rspec] was terminated by signal 9
$ echo $?
137
```

## Bug 2 — the binstub does not isolate Busser from bundler

`busser setup` writes a binstub whose whole job is giving Busser an isolated gem environment on the machine under test. It sets `GEM_HOME`/`GEM_PATH`, then `unset RUBYOPT GEMRC` to keep the caller out.

That is no longer sufficient. **RubyGems requires `bundler/setup` whenever `BUNDLER_SETUP` is set** (`rubygems.rb`), so bundler reactivates inside the Busser process and resets `GEM_HOME` to the calling project's bundle.

Reproduced by running a generated binstub from a project with a vendored bundle:

```
# the binstub exports:
GEM_HOME="/opt/homebrew/lib/ruby/gems/4.0.0"

# but inside the Busser process:
GEM_HOME inside busser = .../proj/vendor/bundle/ruby/4.0.0
bundler loaded?        = YES
```

So Busser installs plugins into, and resolves them from, the calling project's bundle rather than its own isolated home. Test Kitchen invokes Busser from exactly this kind of context.

This is the **same root cause as #54**, which fixed it in the cucumber sandbox. The shipped binstub had the identical stale assumption, and no test.

**Fix:** unset the rest of the bundler variables in both binstubs.

```sh
unset RUBYOPT GEMRC RUBYLIB BUNDLER_SETUP BUNDLER_VERSION
unset BUNDLE_BIN_PATH BUNDLE_GEMFILE BUNDLE_LOCKFILE BUNDLE_PATH
```

After, from the same vendored-bundle project:

```
GEM_HOME inside busser = /opt/homebrew/lib/ruby/gems/4.0.0
bundler loaded?        = no
```

## Tests

`spec/busser/ui_spec.rb` gains signal cases for both `run!` and `run_ruby_script!`; `FakeStatus` learns to model a signalled process (`success?` nil, no `exitstatus`, a `termsig`), which is what made the bug invisible.

`spec/busser/command/setup_spec.rb` is new — the binstub had **no test whatsoever**, so the isolation it exists to provide was never verified. It asserts each leak-prone variable is cleared, in both the bourne and bat binstubs, and that the unsetting happens before the `exec`.

## Verification

```
73 runs, 125 assertions, 0 failures     (was 48 runs, 71 assertions)
16 scenarios (16 passed), 100 steps (100 passed)
cookstyle: 27 files inspected, no offenses detected
```

With the `lib/` fixes reverted: **18 failures**, including `Expected /terminated by signal 9/ to match "!!!!!! Command [failwhale] exit code was \n"` and `Expected ["RUBYOPT", "GEMRC"] to include "BUNDLER_SETUP"`.

Both fixes also re-confirmed end to end against the original reproductions.

## Follow-up

A separate PR covers the `busser plugin create` scaffold, which currently generates a plugin that cannot `bundle install`.