### PR TITLE
refactor: move development dependencies into Gemfile groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,16 @@
 source "https://rubygems.org"
 
-gemspec development_group: :test
+gemspec
+
 group :cookstyle do
-  gem "cookstyle"
+  gem "cookstyle", ">= 9.0"
 end
 
 group :test do
-  gem "minitest", ">= 6.0"
-  gem "base64" # cucumber needs it; not a default gem on Ruby 4.0
+  gem "aruba", ">= 2.4"
+  gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
-  gem "rake"
+  gem "minitest", ">= 6.0"
+  gem "mocha", ">= 2.7"
+  gem "rake", ">= 13.4"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Rake::TestTask.new(:unit) do |t|
 end
 
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = ["features", "-x", "--format progress", "--no-color", "-b"]
+  t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
 desc "Run all test suites"

--- a/busser.gemspec
+++ b/busser.gemspec
@@ -7,25 +7,28 @@ Gem::Specification.new do |spec|
   spec.version       = Busser::VERSION
   spec.authors       = ["Fletcher Nichol"]
   spec.email         = ["fnichol@nichol.ca"]
-  spec.description   = %q{Busser - Runs tests for projects in Test Kitchen}
+  spec.description   = "Busser - Runs tests for projects in Test Kitchen"
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/test-kitchen/busser"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.required_ruby_version = ">= 3.2"
+
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.2"
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/main/CHANGELOG.md",
+    "documentation_uri" => "#{spec.homepage}/blob/main/README.md",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+  }
 
   # thor 1.1.0 references DidYouMean::SPELL_CHECKERS, removed in Ruby 3.1,
   # so the CLI crashed on startup on every supported Ruby
   spec.add_dependency "thor", ">= 1.1"
   # base64 is no longer a default gem; deserialize needs it at runtime
   spec.add_dependency "base64"
-
-  spec.add_development_dependency "aruba", ">= 2.0"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "mocha"
-  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Brings this repository in line with the six busser-* plugins.

The gemspec now declares only what a consumer needs at runtime, so the `gemspec`
directive no longer needs `development_group: :test` to get the test gems into
the right place. Every development dependency carries a version floor at its
current major: cookstyle 9, aruba 2.4, cucumber 11.1, minitest 6, mocha 2.7,
rake 13.4.

The gemspec also picks up metadata URIs for the issue tracker, changelog, docs
and source, drops the %q{} literals, and uses a NUL-separated `git ls-files`
rather than relying on `$/`.

Test tooling:

* `.rubocop.yml` targeted Ruby 3.1 while the gemspec requires 3.2.
* `--fail-fast` replaces `-b` and `-x`. `-x` (`--expand`) only affects Scenario
  Outline output and there are none here; `-b` (`--backtrace`) was noise on a
  suite that already fails loudly.

Signed-off-by: Tim Smith <tsmith84@proton.me>