### PR TITLE
chore: drop the dead rubocop exclusions and fix what they hid

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,4 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.1
-  Exclude:
-    - "vendor/**/*"
-    - "spec/**/*"
+  TargetRubyVersion: 3.2

--- a/spec/busser/command/deserialize_spec.rb
+++ b/spec/busser/command/deserialize_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/busser/command/plugin_create_spec.rb
+++ b/spec/busser/command/plugin_create_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/busser/command/setup_spec.rb
+++ b/spec/busser/command/setup_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/busser/helpers_spec.rb
+++ b/spec/busser/helpers_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../spec_helper'
+require_relative "../spec_helper"
 
-require 'busser/helpers'
+require "busser/helpers"
 
 describe Busser::Helpers do
 
@@ -25,16 +25,16 @@ describe Busser::Helpers do
 
     describe "with a custom root path" do
 
-      before  { ENV['_SPEC_BUSSER_ROOT'] = ENV['BUSSER_ROOT'] }
-      after   { ENV['BUSSER_ROOT'] = ENV.delete('_SPEC_BUSSER_ROOT') }
+      before  { ENV["_SPEC_BUSSER_ROOT"] = ENV["BUSSER_ROOT"] }
+      after   { ENV["BUSSER_ROOT"] = ENV.delete("_SPEC_BUSSER_ROOT") }
 
       it "returns a base path if no suite name is given" do
-        ENV['BUSSER_ROOT'] = "/path/to/busser"
+        ENV["BUSSER_ROOT"] = "/path/to/busser"
         _(suite_path.to_s).must_match %r{/path/to/busser/suites$}
       end
 
       it "returns a suite path given a suite name" do
-        ENV['BUSSER_ROOT'] = "/path/to/busser"
+        ENV["BUSSER_ROOT"] = "/path/to/busser"
         _(suite_path("fuzzy").to_s).must_match %r{/path/to/busser/suites/fuzzy$}
       end
     end
@@ -59,16 +59,16 @@ describe Busser::Helpers do
 
     describe "with a custom root path" do
 
-      before  { ENV['_SPEC_BUSSER_ROOT'] = ENV['BUSSER_ROOT'] }
-      after   { ENV['BUSSER_ROOT'] = ENV.delete('_SPEC_BUSSER_ROOT') }
+      before  { ENV["_SPEC_BUSSER_ROOT"] = ENV["BUSSER_ROOT"] }
+      after   { ENV["BUSSER_ROOT"] = ENV.delete("_SPEC_BUSSER_ROOT") }
 
       it "returns a base path if no product name is given" do
-        ENV['BUSSER_ROOT'] = "/path/to/busser"
+        ENV["BUSSER_ROOT"] = "/path/to/busser"
         _(vendor_path.to_s).must_match %r{/path/to/busser/vendor$}
       end
 
       it "returns a suite path given a product name" do
-        ENV['BUSSER_ROOT'] = "/path/to/busser"
+        ENV["BUSSER_ROOT"] = "/path/to/busser"
         _(vendor_path("maximal").to_s).must_match \
           %r{/path/to/busser/vendor/maximal$}
       end

--- a/spec/busser/plugin_spec.rb
+++ b/spec/busser/plugin_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/busser/ui_spec.rb
+++ b/spec/busser/ui_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../spec_helper'
+require_relative "../spec_helper"
 
-require 'busser/ui'
+require "busser/ui"
 
 # Dummy class containing diagnostic methods approximating Thor mixins
 class SneakyUI
@@ -11,7 +11,7 @@ class SneakyUI
   attr_accessor :status
 
   def say(msg)
-     msg
+    msg
   end
 
   def error(msg)
@@ -111,7 +111,7 @@ describe Busser::UI do
 
       _(ui.run_args).must_equal([
         "doitpls",
-        { :capture => false, :verbose => false}
+        { capture: false, verbose: false },
       ])
     end
 
@@ -181,16 +181,16 @@ describe Busser::UI do
 
       _(ui.run_ruby_script_args).must_equal([
         "theworks.rb",
-        { :capture => false, :verbose => false }
+        { capture: false, verbose: false },
       ])
     end
 
     it "calls #run_ruby_script with correct default options" do
-      ui.invoke_run_ruby_script!("theworks.rb", :verbose => true)
+      ui.invoke_run_ruby_script!("theworks.rb", verbose: true)
 
       _(ui.run_ruby_script_args).must_equal([
         "theworks.rb",
-        { :capture => false, :verbose => true }
+        { capture: false, verbose: true },
       ])
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
@@ -16,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'minitest/autorun'
-require 'mocha/minitest'
+require "minitest/autorun"
+require "mocha/minitest"


### PR DESCRIPTION
`vendor/**/*` was a restatement: RuboCop already excludes it by default, along
with `tmp`, `node_modules` and `.git`. There is no `vendor/` here in any case.

`spec/**/*` was real. It kept the entire unit suite out of the linter, and 35
offences had accumulated behind it -- single-quoted strings, hash rockets, the
`# -*- encoding: utf-8 -*-` magic comments that stopped being necessary in Ruby
2.0, trailing commas and some indentation. All of them are safe-correctable, so
they were fixed with `cookstyle -a` rather than re-excluded.

No exclusion turned out to be necessary, so none is retained with a note.

`cookstyle --chefstyle` now inspects 34 files rather than 27 and reports no
offences, and the suite still passes: 89 unit runs and 16 scenarios.

Signed-off-by: Tim Smith <tsmith84@proton.me>