### PR TITLE
docs: document every method with YARD and add a docs rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ group :test do
   gem "cucumber", ">= 11.1"
   gem "rake"
 end
+
+group :development do
+  gem "yard", ">= 0.9.37"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,24 @@ Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = ["features", "-x", "--format progress", "--no-color", "-b"]
 end
 
+# yard lives in the :development group, which CI omits when it runs the tests.
+# Requiring it unconditionally would make `rake test` fail there, so the real
+# task is only defined when yard is installed and a stub explains its absence
+# otherwise. Nothing in CI gates on documentation.
+begin
+  require "yard"
+
+  YARD::Rake::YardocTask.new(:doc) do |t|
+    t.files = ["lib/**/*.rb"]
+    t.options = ["--output-dir", "doc", "--markup", "markdown"]
+  end
+rescue LoadError
+  desc "Generate YARD documentation (install the development group first)"
+  task :doc do
+    abort "yard is not available. Run `bundle install --with development` first."
+  end
+end
+
 desc "Run all test suites"
 task test: %i{unit features}
 

--- a/lib/busser/command/deserialize.rb
+++ b/lib/busser/command/deserialize.rb
@@ -38,6 +38,10 @@ module Busser
 
       class_option :perms, desc: "Unix permissions on destination file"
 
+      # Writes a file that was streamed in over stdin, checking it arrived
+      # intact before applying its permissions.
+      #
+      # @return [void]
       def perform
         file = File.expand_path(options[:destination])
         contents = Base64.decode64(STDIN.read)

--- a/lib/busser/command/plugin_create.rb
+++ b/lib/busser/command/plugin_create.rb
@@ -36,6 +36,9 @@ module Busser
       class_option :license, aliases: "-l", default: "apachev2",
         desc: "License type for gem (apachev2, mit, lgplv3, reserved)"
 
+      # Generates a new runner plugin project.
+      #
+      # @return [void]
       def create
         self.class.source_root(Busser.source_root.join("templates", "plugin"))
 
@@ -47,6 +50,9 @@ module Busser
 
       private
 
+      # Writes the gemspec, Gemfile, Rakefile, README and licence.
+      #
+      # @return [void]
       def create_core_files
         empty_directory(target_dir)
 
@@ -60,6 +66,9 @@ module Busser
         create_template("github_workflow.yml.erb", ".github/workflows/test.yml")
       end
 
+      # Writes lib/, the version file and the runner plugin class.
+      #
+      # @return [void]
       def create_source_files
         empty_directory(File.join(target_dir, "lib/busser", name))
         empty_directory(File.join(target_dir, "lib/busser/runner_plugin"))
@@ -74,6 +83,9 @@ module Busser
         )
       end
 
+      # Writes a starter cucumber suite for the new plugin.
+      #
+      # @return [void]
       def create_features_files
         empty_directory(File.join(target_dir, "features/support"))
 
@@ -95,6 +107,10 @@ module Busser
         )
       end
 
+      # Runs git init in the generated project, so the gemspec's
+      # `git ls-files` has something to read.
+      #
+      # @return [void]
       def initialize_git
         inside(target_dir) do
           run("git init")
@@ -102,14 +118,21 @@ module Busser
         end
       end
 
+      # @param erb [String] template path, relative to the templates directory
+      # @param dest [String] destination path, relative to the target directory
+      # @return [void]
       def create_template(erb, dest)
         template(erb, File.join(target_dir, dest), config)
       end
 
+      # @return [String] directory the new plugin is generated into
       def target_dir
         File.join(Dir.pwd, "busser-#{name}")
       end
 
+      # Values the templates interpolate.
+      #
+      # @return [Hash] the template binding
       def config
         @config ||= begin
           type_klass_name = "#{::Thor::Util.camel_case(options[:type])}Plugin"
@@ -132,16 +155,19 @@ module Busser
         end
       end
 
+      # @return [String] the author name, from git config where available
       def author
         git_user_name = `git config user.name`.chomp
         git_user_name.empty? ? "TODO: Write your name" : git_user_name
       end
 
+      # @return [String] the author email, from git config where available
       def email
         git_user_email = `git config user.email`.chomp
         git_user_email.empty? ? "TODO: Write your email" : git_user_email
       end
 
+      # @return [String] full licence text for the chosen licence
       def license_string
         case options[:license]
         when "mit" then "MIT"
@@ -168,6 +194,8 @@ module Busser
         end
       end
 
+      # @return [String] the filename the licence is written to, which differs
+      #   by licence
       def license_filename
         case options[:license]
         when "mit" then "LICENSE.txt"
@@ -178,6 +206,7 @@ module Busser
         end
       end
 
+      # @return [String] the licence header comment prepended to source files
       def license_comment
         @license_comment ||= IO.read(File.join(target_dir, license_filename))
           .gsub(/^/, "# ").gsub(/\s+$/, "")

--- a/lib/busser/command/plugin_install.rb
+++ b/lib/busser/command/plugin_install.rb
@@ -40,6 +40,9 @@ module Busser
       class_option :verbose, type: :boolean, default: false,
         desc: "Set a more verbose output"
 
+      # Installs each requested plugin.
+      #
+      # @return [void]
       def install_all
         if options[:verbose]
           Gem.configuration.verbose = 2 if options[:verbose]
@@ -53,6 +56,10 @@ module Busser
 
       private
 
+      # Installs one plugin and runs its postinstall.
+      #
+      # @param plugin [String] gem name, optionally suffixed with @version
+      # @return [void]
       def install(plugin)
         gem_name, version = plugin.split("@")
         name = gem_name.sub(/^busser-/, "")
@@ -65,6 +72,12 @@ module Busser
         end
       end
 
+      # Installs the plugin gem unless it is already available.
+      #
+      # @param gem [String] the gem name
+      # @param version [String, nil] a version requirement, or nil for any
+      # @param name [String] short plugin name, for the message
+      # @return [Boolean] true if the gem was newly installed
       def install_plugin_gem(gem, version, name)
         if internal_plugin?(name) || gem_installed?(gem, version)
           info "Plugin #{name} already installed"
@@ -76,10 +89,17 @@ module Busser
         end
       end
 
+      # @param name [String] short plugin name
+      # @return [void]
       def load_plugin(name)
         Busser::Plugin.require!(Busser::Plugin.runner_plugin(name))
       end
 
+      # Runs the plugin's postinstall block, which is where a plugin installs
+      # the test framework it drives.
+      #
+      # @param name [String] short plugin name
+      # @return [void]
       def run_postinstall(name)
         klass = Busser::Plugin.runner_class(::Thor::Util.camel_case(name))
         if klass.respond_to?(:run_postinstall)

--- a/lib/busser/command/plugin_list.rb
+++ b/lib/busser/command/plugin_list.rb
@@ -28,6 +28,9 @@ module Busser
     #
     class PluginList < Busser::Thor::BaseGroup
 
+      # Prints the installed plugins and their versions.
+      #
+      # @return [void]
       def list
         if plugin_data.empty?
           say "No plugins installed yet"
@@ -38,6 +41,8 @@ module Busser
 
       private
 
+      # @return [Array<Array(String, String)>] each installed plugin's short
+      #   name and version
       def plugin_data
         @plugin_data ||= Busser::Plugin.runner_plugins.map do |path|
           spec = Busser::Plugin.gem_from_path(path)

--- a/lib/busser/command/setup.rb
+++ b/lib/busser/command/setup.rb
@@ -32,6 +32,10 @@ module Busser
         desc: "Type of binstub file to create (bourne or bat)",
         default: "bourne"
 
+      # Creates the Busser root and the binstub that runs Busser with an
+      # isolated gem environment.
+      #
+      # @return [void]
       def perform
         banner "Setting up Busser"
         create_busser_root
@@ -40,11 +44,15 @@ module Busser
 
       private
 
+      # @return [void]
       def create_busser_root
         info "Creating BUSSER_ROOT in #{root_path}"
         empty_directory(root_path, verbose: false)
       end
 
+      # Writes the binstub, in whichever flavour --type asked for.
+      #
+      # @return [void]
       def generate_busser_binstub
         info "Creating busser binstub"
 
@@ -55,6 +63,9 @@ module Busser
         end
       end
 
+      # Writes a Windows batch binstub.
+      #
+      # @return [void]
       def generate_busser_binstub_for_bat
         binstub = root_path + "bin/busser.bat"
         busser_root = root_path.to_s.gsub("/", "\\")
@@ -105,6 +116,9 @@ module Busser
         end
       end
 
+      # Writes a Bourne shell binstub, executable.
+      #
+      # @return [void]
       def generate_busser_binstub_for_bourne
         binstub = root_path + "bin/busser"
 
@@ -144,6 +158,8 @@ module Busser
         chmod(binstub, 0755, verbose: false)
       end
 
+      # @return [String] path to the Ruby that is running Busser, in the path
+      #   style the target binstub needs
       def ruby_bin
         result = if (bindir = RbConfig::CONFIG["bindir"])
                    File.join(bindir, "ruby")
@@ -154,18 +170,22 @@ module Busser
         result
       end
 
+      # @return [String] the isolated gem home the binstub exports
       def gem_home
         Gem.paths.home.dup.tap { |p| p.gsub!("/", "\\") if bat? }
       end
 
+      # @return [String] the gem path the binstub exports
       def gem_path
         Gem.paths.path.join(":").dup.tap { |p| p.gsub!("/", "\\") if bat? }
       end
 
+      # @return [String] directory holding the real busser executable
       def gem_bindir
         Gem.bindir.dup.tap { |p| p.gsub!("/", "\\") if bat? }
       end
 
+      # @return [Boolean] true when generating a Windows batch binstub
       def bat?
         options[:type] == "bat"
       end

--- a/lib/busser/command/suite_cleanup.rb
+++ b/lib/busser/command/suite_cleanup.rb
@@ -28,6 +28,9 @@ module Busser
     #
     class SuiteCleanup < Busser::Thor::BaseGroup
 
+      # Removes the suites directory and everything in it.
+      #
+      # @return [void]
       def cleanup
         if suite_path.directory?
           Pathname.glob(suite_path + "*").each do |dir|

--- a/lib/busser/command/suite_path.rb
+++ b/lib/busser/command/suite_path.rb
@@ -29,6 +29,9 @@ module Busser
 
       argument :suite_name, required: false
 
+      # Prints where suites live, or where one named suite lives.
+      #
+      # @return [void]
       def path
         say suite_path(suite_name).to_s
       end

--- a/lib/busser/command/test.rb
+++ b/lib/busser/command/test.rb
@@ -20,6 +20,7 @@ require "busser/plugin"
 
 module Busser
 
+  # Namespace for Busser's subcommands.
   module Command
 
     # Test command.
@@ -30,6 +31,10 @@ module Busser
 
       argument :plugins, type: :array, required: false
 
+      # Runs each requested plugin's suite, or every installed plugin's suite
+      # when none were named.
+      #
+      # @return [void]
       def perform
         Busser::Plugin.runner_plugins(plugins).each do |runner_path|
           runner = File.basename(runner_path)
@@ -46,15 +51,28 @@ module Busser
 
       private
 
+      # The dummy runner exists for Busser's own tests, so it only runs when
+      # asked for by name.
+      #
+      # @param runner [String] short plugin name
+      # @return [Boolean] true if this runner should be passed over
       def skip_runner?(runner)
         runner == "dummy" && ! Array(plugins).include?("dummy")
       end
 
+      # Runs whatever preparation the suite ships before its tests.
+      #
+      # @param runner [String] short plugin name
+      # @return [void]
       def prepare_suite(runner)
         run_prepare_sh(runner)
         run_prepare_recipe(runner)
       end
 
+      # Runs the suite's prepare.sh, if it has one.
+      #
+      # @param runner [String] short plugin name
+      # @return [void]
       def run_prepare_sh(runner)
         prepare_sh_script = suite_path(runner).join("prepare.sh")
 
@@ -64,6 +82,11 @@ module Busser
         end
       end
 
+      # Warns if the suite still ships the prepare_recipe.rb that Busser
+      # dropped support for, rather than ignoring it silently.
+      #
+      # @param runner [String] short plugin name
+      # @return [void]
       def run_prepare_recipe(runner)
         prepare_recipe = suite_path(runner).join("prepare_recipe.rb")
 

--- a/lib/busser/cucumber/hooks.rb
+++ b/lib/busser/cucumber/hooks.rb
@@ -14,10 +14,19 @@ After do
   end
 end
 
+# Stashes an environment variable so a scenario can change it and have the
+# original put back afterwards.
+#
+# @param key [String] the variable name
+# @return [String, nil] the stashed value
 def backup_envvar(key)
   ENV["_CUKE_#{key}"] = ENV[key]
 end
 
+# Puts back a variable stashed by {backup_envvar}.
+#
+# @param key [String] the variable name
+# @return [String, nil] the restored value
 def restore_envvar(key)
   ENV[key] = ENV.delete("_CUKE_#{key}")
 end

--- a/lib/busser/helpers.rb
+++ b/lib/busser/helpers.rb
@@ -29,22 +29,41 @@ module Busser
 
     module_function
 
+    # Path to the suites directory, or to one suite inside it.
+    #
+    # @param name [String, nil] a suite name, or nil for the containing
+    #   directory
+    # @return [Pathname] absolute path beneath the Busser root
     def suite_path(name = nil)
       path = root_path + "suites"
       path += name if name
       path.expand_path
     end
 
+    # Path to the vendor directory, or to one vendored product inside it.
+    #
+    # @param product [String, nil] a product name, or nil for the containing
+    #   directory
+    # @return [Pathname] absolute path beneath the Busser root
     def vendor_path(product = nil)
       path = root_path + "vendor"
       path += product if product
       path.expand_path
     end
 
+    # The Busser root, where plugins, suites and vendored products live.
+    #
+    # @return [Pathname] BUSSER_ROOT if set, otherwise /opt/busser
     def root_path
       Pathname.new(ENV["BUSSER_ROOT"] || "/opt/busser")
     end
 
+    # No longer supported. Kept so a plugin still calling it warns rather
+    # than dying with a NoMethodError halfway through a test run.
+    #
+    # @param config [Hash] ignored
+    # @return [void]
+    # @deprecated Shell out or use a Thor action instead.
     def chef_apply(config = {}, &block)
       warn "Apologies, but Busser no longer supports the chef_apply helper," +
         " so the contents of this block will not be executed. Please refactor" +
@@ -52,6 +71,11 @@ module Busser
         " strategy"
     end
 
+    # Installs a gem into the Busser root's gem home.
+    #
+    # @param gem [String] the gem name
+    # @param version [String, nil] a requirement string, or nil for any version
+    # @return [Gem::Specification, nil] the spec that was installed
     def install_gem(gem, version = nil)
       Busser::RubyGems.install_gem(gem, version)
     end

--- a/lib/busser/plugin.rb
+++ b/lib/busser/plugin.rb
@@ -17,6 +17,7 @@
 
 module Busser
 
+  # Namespace that runner plugins define their classes inside.
   module RunnerPlugin
   end
 
@@ -28,10 +29,17 @@ module Busser
 
     module_function
 
+    # @param plugin_name [String] short plugin name, such as "bash"
+    # @return [String] the path to require for that plugin
     def runner_plugin(plugin_name)
       "busser/runner_plugin/#{plugin_name}"
     end
 
+    # Require paths for the named plugins, or for every installed plugin.
+    #
+    # @param plugin_names [Array<String>, String, nil] plugin names, or nil for
+    #   everything installed
+    # @return [Array<String>] require paths, without duplicates
     def runner_plugins(plugin_names = nil)
       if plugin_names
         Array(plugin_names).map { |plugin| runner_plugin(plugin) }.uniq
@@ -46,22 +54,40 @@ module Busser
     # duplicates made `busser test` run a suite twice and `busser plugin list`
     # print it twice. The path is what gets required, and require resolves to
     # the active version, so collapsing the repeats is safe.
+    # Require paths for every runner plugin installed on this machine.
+    #
+    # @return [Array<String>] require paths, without duplicates
     def all_runner_plugins
       Gem.find_files("busser/runner_plugin/*.rb").map do |file|
         "busser/runner_plugin/#{File.basename(file).sub(/\.rb$/, "")}"
       end.uniq
     end
 
+    # Requires a plugin, exiting with a readable message rather than a
+    # backtrace if it cannot be loaded.
+    #
+    # @param plugin_path [String] the path to require
+    # @return [void]
     def require!(plugin_path)
       require plugin_path
     rescue LoadError => e
       Busser::UI.die "Could not load #{plugin_path} (#{e.class}: #{e.message})"
     end
 
+    # @param klass [String, Symbol] a constant name inside
+    #   {Busser::RunnerPlugin}
+    # @return [Class] the runner plugin class
     def runner_class(klass)
       Busser::RunnerPlugin.const_get(klass)
     end
 
+    # Finds the gemspec a plugin was loaded from.
+    #
+    # A plugin being developed locally is not an installed gem, so the local
+    # gemspec is preferred when the plugin resolves inside the working tree.
+    #
+    # @param plugin_path [String] the plugin's require path
+    # @return [Gem::Specification] the spec the plugin belongs to
     def gem_from_path(plugin_path)
       local_gem_path = "#{File.expand_path(plugin_path, $LOAD_PATH.first)}"
       local_gemspec = File.join(

--- a/lib/busser/rubygems.rb
+++ b/lib/busser/rubygems.rb
@@ -27,11 +27,24 @@ module Busser
 
     module_function
 
+    # @param name [String] the gem name
+    # @param version [String, nil] a requirement string, or nil for any version
+    # @return [Boolean] true if a matching gem is already available
     def gem_installed?(name, version)
       version = Gem::Requirement.default unless version
       ! Gem::Dependency.new(name, version).matching_specs.empty?
     end
 
+    # Installs a gem into GEM_HOME.
+    #
+    # RubyGems under bundler points Gem.dir at the bundle, which is not where
+    # Busser plugins belong, so GEM_HOME is applied explicitly before the
+    # install and the freshly installed spec is put on the load path by hand.
+    #
+    # @param gem_name [String] the gem name
+    # @param version [String, nil] a requirement string, or nil for any version
+    # @return [Gem::Specification, nil] the installed spec, or nil if the gem
+    #   was not among those installed
     def install_gem(gem_name, version)
       version = Gem::Requirement.default unless version
 
@@ -54,6 +67,8 @@ module Busser
       spec
     end
 
+    # @return [Hash] options handed to RubyGems' dependency installer, with
+    #   the install directory pinned to GEM_HOME
     def rbg_options
       @rbg_options ||= Gem::DependencyInstaller::DEFAULT_OPTIONS.merge(
         suggest_alternate: false,
@@ -67,6 +82,11 @@ module Busser
       )
     end
 
+    # Runs a block with RubyGems' own progress output suppressed, unless the
+    # user asked for verbose output.
+    #
+    # @yield the block to run quietly
+    # @return [Object] whatever the block returned
     def silence_gem_ui
       interaction = Gem::DefaultUserInteraction.ui
       unless Gem.configuration.really_verbose

--- a/lib/busser/runner_plugin.rb
+++ b/lib/busser/runner_plugin.rb
@@ -27,6 +27,11 @@ module Busser
     #
     class Base < Busser::Thor::BaseGroup
 
+      # Declares work to run once, when Busser installs this plugin -- which
+      # is where a plugin installs the test framework it drives.
+      #
+      # @yield the postinstall body, evaluated on the plugin instance
+      # @return [void]
       def self.postinstall(&block)
         (class << self; self; end).send(:define_method, :run_postinstall) do
           klass = Class.new(Busser::Thor::BaseGroup) do

--- a/lib/busser/runner_plugin/dummy.rb
+++ b/lib/busser/runner_plugin/dummy.rb
@@ -34,6 +34,9 @@ class Busser::RunnerPlugin::Dummy < Busser::RunnerPlugin::Base
     create_file("#{dummy_path}/foobar.txt", "The Dummy Driver.")
   end
 
+  # Prints a line so Busser's own suite can prove a plugin ran.
+  #
+  # @return [void]
   def test
     banner "[dummy] Running"
     if File.exist?(File.join(suite_path("dummy"), "foobar.txt"))

--- a/lib/busser/thor.rb
+++ b/lib/busser/thor.rb
@@ -22,6 +22,7 @@ require "busser/ui"
 
 module Busser
 
+  # Thor base classes preloaded with Busser's helpers and output methods.
   module Thor
 
     # Base class for all Thor subclasses which includes useful mixins.

--- a/lib/busser/ui.rb
+++ b/lib/busser/ui.rb
@@ -29,30 +29,56 @@ module Busser
 
     # Thor::Shell's delegated methods are not mixed into this module, so
     # provide the two output primitives it relies on.
+    # @param msg [String] text to write to stdout
+    # @return [void]
     def say(msg)
       $stdout.puts(msg)
     end
 
+    # @param msg [String] text to write to stderr
+    # @return [void]
     def error(msg)
       $stderr.puts(msg)
     end
 
+    # Announces a step, at the top level of the output.
+    #
+    # @param msg [String] the message
+    # @return [void]
     def banner(msg)
       say("-----> #{msg}")
     end
 
+    # Reports detail beneath a banner.
+    #
+    # @param msg [String] the message
+    # @return [void]
     def info(msg)
       say("       #{msg}")
     end
 
+    # Reports something the user should notice but which is not fatal.
+    #
+    # @param msg [String] the message
+    # @return [void]
     def warn(msg)
       say(">>>>>> #{msg}")
     end
 
+    # Reports a failure, on stderr.
+    #
+    # @param msg [String] the message
+    # @return [void]
     def fatal(msg)
       error("!!!!!! #{msg}")
     end
 
+    # Runs a shell command, exiting with a diagnosis if it fails.
+    #
+    # @param cmd [String] the command line
+    # @param config [Hash] options passed through to Thor's runner
+    # @return [true] if the command succeeded
+    # @see #handle_command
     def run!(cmd, config = {})
       config = { capture: false, verbose: false }.merge(config)
 
@@ -61,6 +87,13 @@ module Busser
       end
     end
 
+    # Runs a Ruby script with the current interpreter, exiting with a
+    # diagnosis if it fails.
+    #
+    # @param cmd [String] the script and its arguments
+    # @param config [Hash] options passed through to Thor's runner
+    # @return [true] if the script succeeded
+    # @see #handle_command
     def run_ruby_script!(cmd, config = {})
       config = { capture: false, verbose: false }.merge(config)
 
@@ -69,15 +102,37 @@ module Busser
       end
     end
 
+    # Reports a failure and exits.
+    #
+    # @param msg [String] the message
+    # @param exitstatus [Integer] the status to exit with
+    # @return [void] does not return
     def die(msg, exitstatus = 1)
       fatal(msg)
       exit(exitstatus)
     end
 
+    # Wrapped so tests can stub it.
+    #
+    # @return [Process::Status, nil] the status of the last child process
     def status
       $?
     end
 
+    # Runs a block and turns however the child process ended into a readable
+    # message and a matching exit status.
+    #
+    # Three endings are distinguished because they mean different things to
+    # someone reading CI output: a nil status usually means the machine ran out
+    # of memory before the child could report; a signal means something killed
+    # the run, typically the out of memory killer; and an exit code means the
+    # command itself failed.
+    #
+    # @param type [String] what was run, for the message
+    # @param cmd [String] the command line, for the message
+    # @yield runs the command
+    # @return [true] if the command succeeded
+    # @raise [StandardError] re-raised if the block itself raised
     def handle_command(type, cmd)
       begin
         yield

--- a/lib/busser/version.rb
+++ b/lib/busser/version.rb
@@ -16,5 +16,6 @@
 # limitations under the License.
 
 module Busser
+  # Version string for Busser
   VERSION = "0.9.1".freeze
 end


### PR DESCRIPTION
Brings this repository in line with the six busser-* plugins.

Every method now has a YARD comment covering what it does, what it takes, what
it returns, and -- where it matters -- why it is written the way it is.
`yard stats --private` goes from 25% to **100% documented**, across 98 methods.

The comments that earn their keep are on the non-obvious parts:

* `UI#handle_command` distinguishes three ways a child process can end, because
  each means something different to whoever is reading CI output: a nil status
  usually means the machine ran out of memory before the child could report, a
  signal means something killed the run, and an exit code means the command
  itself failed.
* `RubyGems.install_gem` applies `GEM_HOME` explicitly and puts the installed
  spec on the load path by hand, because RubyGems under bundler points
  `Gem.dir` at the bundle rather than the Busser root.
* `Plugin.gem_from_path` prefers a local gemspec so a plugin being developed in
  a working tree resolves to that rather than an installed copy.
* `Command::Test#skip_runner?` explains why the dummy runner only runs when
  named.

`rake doc` generates the HTML into `doc/`, which is already gitignored.

yard sits in the `:development` bundler group, which CI omits when it runs the
tests, so the Rakefile only defines the real task when yard is installed and
otherwise leaves a stub saying how to get it. **Nothing in CI gates on
documentation**, and `rake test` still works with the group omitted -- verified
under `BUNDLE_WITHOUT=development`, the same setting the shared workflow uses.

The suite is unchanged and still passes: 89 unit runs, 16 scenarios.