### PR TITLE
fix: restore SSL verification if a plugin postinstall raises

### DIFF
--- a/lib/busser/command/plugin_install.rb
+++ b/lib/busser/command/plugin_install.rb
@@ -120,13 +120,29 @@ module Busser
       #
       # Please use with extreme caution.
       #
+      # The restore is in an ensure block. Without one, a postinstall that
+      # raised left VERIFY_PEER set to VERIFY_NONE for the rest of the
+      # process -- and `busser plugin install` takes a list, so every gem
+      # downloaded for every later plugin in that same run would have had its
+      # certificate unchecked.
+      #
+      # @yield the block to run with peer verification dropped
+      # @return [void]
       def drop_ssl_verify_peer
         before = OpenSSL::SSL::VERIFY_PEER
+        set_ssl_verify_peer(OpenSSL::SSL::VERIFY_NONE)
+        begin
+          yield
+        ensure
+          set_ssl_verify_peer(before)
+        end
+      end
+
+      # @param value [Integer] the OpenSSL verify mode to install
+      # @return [void]
+      def set_ssl_verify_peer(value)
         OpenSSL::SSL.send(:remove_const, "VERIFY_PEER")
-        OpenSSL::SSL.const_set("VERIFY_PEER", OpenSSL::SSL::VERIFY_NONE)
-        yield
-        OpenSSL::SSL.send(:remove_const, "VERIFY_PEER")
-        OpenSSL::SSL.const_set("VERIFY_PEER", before)
+        OpenSSL::SSL.const_set("VERIFY_PEER", value)
       end
     end
   end

--- a/spec/busser/command/plugin_install_spec.rb
+++ b/spec/busser/command/plugin_install_spec.rb
@@ -1,0 +1,44 @@
+require_relative "../../spec_helper"
+
+require "busser/command/plugin_install"
+
+describe Busser::Command::PluginInstall do
+  let(:command) { Busser::Command::PluginInstall.new([%w{busser-dummy}]) }
+
+  describe "#drop_ssl_verify_peer" do
+    # VERIFY_PEER is a process-global constant, so anything that leaves it
+    # lowered affects every later gem download in the same run. `busser plugin
+    # install` takes a list of plugins, which is exactly that situation.
+    it "lowers verification for the block" do
+      inside = nil
+      command.send(:drop_ssl_verify_peer) { inside = OpenSSL::SSL::VERIFY_PEER }
+
+      _(inside).must_equal OpenSSL::SSL::VERIFY_NONE
+    end
+
+    it "restores verification afterwards" do
+      before = OpenSSL::SSL::VERIFY_PEER
+      command.send(:drop_ssl_verify_peer) { nil }
+
+      _(OpenSSL::SSL::VERIFY_PEER).must_equal before
+    end
+
+    # The regression this guards. A postinstall raising is not exotic: it is
+    # how a plugin reports that it could not install its test framework.
+    it "restores verification when the block raises" do
+      before = OpenSSL::SSL::VERIFY_PEER
+
+      _(proc { command.send(:drop_ssl_verify_peer) { raise "postinstall blew up" } })
+        .must_raise RuntimeError
+
+      _(OpenSSL::SSL::VERIFY_PEER).must_equal before
+    end
+
+    it "restores verification when the block throws" do
+      before = OpenSSL::SSL::VERIFY_PEER
+      catch(:done) { command.send(:drop_ssl_verify_peer) { throw :done } }
+
+      _(OpenSSL::SSL::VERIFY_PEER).must_equal before
+    end
+  end
+end


### PR DESCRIPTION
drop_ssl_verify_peer lowered OpenSSL::SSL::VERIFY_PEER to VERIFY_NONE, yielded,
and then restored it. With no ensure, a postinstall that raised never reached
the restore.

VERIFY_PEER is a process-global constant, and `busser plugin install` takes a
list, so a single plugin failing its postinstall left every gem downloaded for
every later plugin in that run with its TLS certificate unchecked. A postinstall
raising is not exotic -- it is how a plugin reports that it could not install
the test framework it drives.

The restore now runs in an ensure block. Four specs cover it: the block sees the
lowered value, it is restored on the happy path, it is restored when the block
raises, and it is restored when the block throws.

Signed-off-by: Tim Smith <tsmith84@proton.me>

Verified the specs bite: reverting to the un-ensured restore fails the raise case.