### PR TITLE
fix: quote the prepare.sh path before handing it to a shell

### DIFF
--- a/lib/busser/command/test.rb
+++ b/lib/busser/command/test.rb
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "shellwords" unless defined?(Shellwords)
+
 require "busser/thor"
 require "busser/plugin"
 
@@ -49,6 +51,18 @@ module Busser
         end
       end
 
+      # Builds the command that runs a suite's prepare.sh.
+      #
+      # The path is quoted. It is rooted at BUSSER_ROOT, which the caller
+      # chooses, so an unquoted path containing a space would be split by the
+      # shell and sh would be handed a fragment instead of the script.
+      #
+      # @param script [String, Pathname] path to the prepare.sh
+      # @return [String] the command to run
+      def self.prepare_sh_command(script)
+        "/bin/sh #{Shellwords.escape(script.to_s)}"
+      end
+
       private
 
       # The dummy runner exists for Busser's own tests, so it only runs when
@@ -78,7 +92,7 @@ module Busser
 
         if prepare_sh_script.exist?
           banner "Preparing #{runner} suite with #{prepare_sh_script}"
-          run!("/bin/sh #{prepare_sh_script}")
+          run!(self.class.prepare_sh_command(prepare_sh_script))
         end
       end
 

--- a/spec/busser/command/test_spec.rb
+++ b/spec/busser/command/test_spec.rb
@@ -1,0 +1,36 @@
+require_relative "../../spec_helper"
+
+require "shellwords"
+require "busser/command/test"
+
+describe Busser::Command::Test do
+  describe ".prepare_sh_command" do
+    it "runs the script with sh" do
+      cmd = Busser::Command::Test.prepare_sh_command("/opt/busser/suites/bats/prepare.sh")
+
+      _(Shellwords.split(cmd)).must_equal ["/bin/sh", "/opt/busser/suites/bats/prepare.sh"]
+    end
+
+    # BUSSER_ROOT is chosen by whoever runs Busser, and Test Kitchen puts it
+    # under a path the user controls. Unquoted, a space split the path and sh
+    # was handed a fragment.
+    it "quotes a path containing spaces" do
+      cmd = Busser::Command::Test.prepare_sh_command("/tmp/my tests/suites/bats/prepare.sh")
+
+      _(Shellwords.split(cmd))
+        .must_equal ["/bin/sh", "/tmp/my tests/suites/bats/prepare.sh"]
+    end
+
+    it "neutralises shell metacharacters in the path" do
+      cmd = Busser::Command::Test.prepare_sh_command("/tmp/a;touch pwned/prepare.sh")
+
+      _(Shellwords.split(cmd)).must_equal ["/bin/sh", "/tmp/a;touch pwned/prepare.sh"]
+    end
+
+    it "accepts a Pathname" do
+      cmd = Busser::Command::Test.prepare_sh_command(Pathname.new("/a/prepare.sh"))
+
+      _(Shellwords.split(cmd).last).must_equal "/a/prepare.sh"
+    end
+  end
+end


### PR DESCRIPTION
`busser test` ran a suite prepare script as `/bin/sh #{path}` with the path
interpolated raw. That path is rooted at BUSSER_ROOT, which the caller chooses
and Test Kitchen places under a user-controlled directory, so a space anywhere
in it split the command and sh was handed a fragment instead of the script.

The command is now built by Test.prepare_sh_command, which escapes the path.
The specs assert on Shellwords.split -- what a shell would actually see -- so
they check the property rather than the escaping syntax.

Signed-off-by: Tim Smith <tsmith84@proton.me>