### PR TITLE
ci: verify releases reach RubyGems and keep versions in the 0.x series

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,3 +43,25 @@ jobs:
         uses: actionshub/publish-gem-to-rubygems@f9126f7a2d36a4fd31a13e78fde5fbdcc4b7b251  # v2.0.6
         with:
           token: ${{ secrets.RUBYGEMS_API_KEY }}
+
+      # actionshub/publish-gem-to-rubygems logs a rejected push and still exits
+      # 0, so a release that never reached RubyGems shows up as a green job.
+      # Ask RubyGems directly instead of trusting the step. The v2 endpoint is
+      # 404 until the exact version is indexed, so -f turns "not there" into a
+      # non-zero exit rather than a substring match on `gem list` output.
+      - name: Verify the release reached RubyGems
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          name="$(basename "$(ls ./*.gemspec)" .gemspec)"
+          for _ in $(seq 1 12); do
+            if curl -fsS -o /dev/null "https://rubygems.org/api/v2/rubygems/${name}/versions/${VERSION}.json"; then
+              echo "${name} ${VERSION} is on RubyGems"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::${name} ${VERSION} never reached RubyGems. A permissions failure in the push step above does not fail that step -- read its log."
+          exit 1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "ruby",
       "include-component-in-tag": false,
-      "version-file": "lib/busser/version.rb"
+      "version-file": "lib/busser/version.rb",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Two gaps the busser-* plugins already closed.

**Silent publish failures.** actionshub/publish-gem-to-rubygems logs a rejected
push and still exits 0. busser-bash hit exactly that: v0.2.0 was tagged, the
GitHub release was cut, GitHub Packages got the gem, the workflow went green,
and RubyGems stayed on 0.1.4 because the push had been rejected with "You do not
have permission to push to this gem". A new step asks RubyGems whether the
version actually landed and fails the job if it never does.

**Version graduation.** Without bump-minor-pre-major, release-please reads the
"!" on a breaking change as a graduation to 1.0.0. busser is 0.9.1, and the next
breaking change would have jumped it to 1.0 rather than 0.10. A breaking change
now takes the minor and an ordinary feature takes the patch, matching the six
plugins.

Signed-off-by: Tim Smith <tsmith84@proton.me>