### PR TITLE
fix: tell Thor to exit non-zero when a command fails

### DIFF
--- a/lib/busser/thor.rb
+++ b/lib/busser/thor.rb
@@ -34,6 +34,17 @@ module Busser
       include Helpers
       include UI
       include ::Thor::Actions
+
+      # Thor exits 0 when a command fails unless this is true, and warns on
+      # every failure that it is not set. Busser is a test runner: a failure
+      # has to be a non-zero exit or CI reports a red suite as green. Thor 2
+      # makes this the default; setting it now silences the deprecation on
+      # every failing run and pins the behaviour we already rely on.
+      #
+      # @return [true]
+      def self.exit_on_failure?
+        true
+      end
     end
 
     # Base class for all Thor Group subclasses which includes useful mixins.
@@ -45,6 +56,17 @@ module Busser
       include Helpers
       include UI
       include ::Thor::Actions
+
+      # Thor exits 0 when a command fails unless this is true, and warns on
+      # every failure that it is not set. Busser is a test runner: a failure
+      # has to be a non-zero exit or CI reports a red suite as green. Thor 2
+      # makes this the default; setting it now silences the deprecation on
+      # every failing run and pins the behaviour we already rely on.
+      #
+      # @return [true]
+      def self.exit_on_failure?
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
fix: tell Thor to exit non-zero when a command fails

Thor exits 0 on a failed command unless exit_on_failure? is true, and warns on
every failure that it is not set. Neither base class defined it, so every
failing test run printed this before the actual failure:

```text
-----> [bash] failing_test.sh
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior,
you must define `exit_on_failure?` in `Busser::RunnerPlugin::Bash`
!!!!!! Command [bash .../failing_test.sh] exit code was 1
```

Busser is a test runner, so exiting 0 on a failure is precisely the wrong
default -- CI would report a red suite as green. The current non-zero exit comes
from UI#die calling exit directly, which papers over the Thor default rather
than setting it.

Defining it on Busser::Thor::Base and BaseGroup fixes it for busser and for
every runner plugin at once, since they all inherit from BaseGroup. Thor 2 makes
this the default, so this also pins behaviour that is about to change under us.

Verified against a real failing suite: the warning is gone and the exit status
is still 1.