### PR TITLE
fix: stop `busser plugin list` printing git errors and a phantom plugin

### DIFF
--- a/lib/busser/command/plugin_list.rb
+++ b/lib/busser/command/plugin_list.rb
@@ -41,13 +41,20 @@ module Busser
 
       private
 
+      # The dummy runner is a fixture shipped inside busser for its own tests,
+      # not something anyone installed. `busser test` already passes over it,
+      # so listing it as an installed plugin was inconsistent as well as
+      # confusing.
+      #
       # @return [Array<Array(String, String)>] each installed plugin's short
       #   name and version
       def plugin_data
-        @plugin_data ||= Busser::Plugin.runner_plugins.map do |path|
-          spec = Busser::Plugin.gem_from_path(path)
-          [File.basename(path), (spec && spec.version)]
-        end
+        @plugin_data ||= Busser::Plugin.runner_plugins
+          .reject { |path| File.basename(path) == "dummy" }
+          .map do |path|
+            spec = Busser::Plugin.gem_from_path(path)
+            [File.basename(path), (spec && spec.version)]
+          end
       end
     end
   end

--- a/lib/busser/plugin.rb
+++ b/lib/busser/plugin.rb
@@ -89,16 +89,32 @@ module Busser
     # @param plugin_path [String] the plugin's require path
     # @return [Gem::Specification] the spec the plugin belongs to
     def gem_from_path(plugin_path)
-      local_gem_path = "#{File.expand_path(plugin_path, $LOAD_PATH.first)}"
-      local_gemspec = File.join(
-        File.dirname($LOAD_PATH.first), "busser.gemspec"
-      )
+      # Ask RubyGems first. Loading a gemspec *evaluates* it, and these
+      # gemspecs shell out to `git ls-files` to build their file list -- so
+      # asking the working tree first printed "fatal: not a git repository"
+      # into the middle of `busser plugin list` for every installed plugin.
+      # find_by_path answers from the installed specs without running anything.
+      Gem::Specification.find_by_path(plugin_path) ||
+        local_gemspec_for(plugin_path)
+    end
 
-      if ! Dir.glob("#{local_gem_path}#{Gem.suffix_pattern}").empty?
-        Gem::Specification.load(File.expand_path(local_gemspec))
-      else
-        Gem::Specification.find_by_path(plugin_path)
-      end
+    # Falls back to a gemspec in the working tree, which is how a plugin being
+    # developed locally -- and so not installed as a gem -- is resolved.
+    #
+    # @param plugin_path [String] the plugin's require path
+    # @return [Gem::Specification, nil] the spec, or nil if there is no local
+    #   gemspec to read
+    def local_gemspec_for(plugin_path)
+      root = $LOAD_PATH.first
+      return nil if root.nil?
+
+      local_gem_path = File.expand_path(plugin_path, root)
+      return nil if Dir.glob("#{local_gem_path}#{Gem.suffix_pattern}").empty?
+
+      local_gemspec = File.join(File.dirname(root), "busser.gemspec")
+      return nil unless File.exist?(local_gemspec)
+
+      Gem::Specification.load(local_gemspec)
     end
   end
 end

--- a/spec/busser/command/plugin_list_spec.rb
+++ b/spec/busser/command/plugin_list_spec.rb
@@ -1,0 +1,49 @@
+require_relative "../../spec_helper"
+
+require "busser/command/plugin_list"
+
+describe Busser::Command::PluginList do
+  let(:command) { Busser::Command::PluginList.new }
+
+  describe "#plugin_data" do
+    def stub_plugins(paths, specs = {})
+      Busser::Plugin.stubs(:runner_plugins).returns(paths)
+      paths.each do |path|
+        Busser::Plugin.stubs(:gem_from_path).with(path).returns(specs[path])
+      end
+    end
+
+    def spec_for(name, version)
+      Gem::Specification.new { |s| s.name = name; s.version = version }
+    end
+
+    it "reports each plugin's short name and version" do
+      stub_plugins(["busser/runner_plugin/bash"],
+        "busser/runner_plugin/bash" => spec_for("busser-bash", "0.2.0"))
+
+      _(command.send(:plugin_data)).must_equal [["bash", Gem::Version.new("0.2.0")]]
+    end
+
+    # dummy is a fixture shipped inside busser for its own tests, not something
+    # anyone installed. `busser test` already passes over it, so listing it was
+    # inconsistent as well as confusing.
+    it "leaves out the internal dummy runner" do
+      stub_plugins(["busser/runner_plugin/dummy", "busser/runner_plugin/bash"],
+        "busser/runner_plugin/bash" => spec_for("busser-bash", "0.2.0"))
+
+      _(command.send(:plugin_data).map(&:first)).must_equal %w{bash}
+    end
+
+    it "reports a nil version rather than raising when no spec is found" do
+      stub_plugins(["busser/runner_plugin/bash"])
+
+      _(command.send(:plugin_data)).must_equal [["bash", nil]]
+    end
+
+    it "returns an empty list when dummy is all there is" do
+      stub_plugins(["busser/runner_plugin/dummy"])
+
+      _(command.send(:plugin_data)).must_be_empty
+    end
+  end
+end


### PR DESCRIPTION
fix: stop `busser plugin list` printing git errors and a phantom plugin

Running the command against a normal install produced this:

```text
$ busser plugin list
fatal: not a git repository (or any of the parent directories): .git
Plugin  Version
dummy   0.9.1
bash    0.1.4
```

Two separate problems, both user visible on a command people reach for when
something is not working.

**The git error.** `gem_from_path` preferred loading a gemspec *file* over
asking RubyGems. Loading a gemspec evaluates it, and these gemspecs shell out to
`git ls-files` to build their file list -- so every installed plugin printed a
git failure from a directory that is not a checkout. It now asks
`Gem::Specification.find_by_path` first, which answers from the installed specs
without running anything, and only falls back to a working-tree gemspec when
that comes back empty, which is the local-development case the fallback was for.
The fallback also now checks the gemspec exists before loading it.

**The phantom plugin.** `dummy` is a fixture shipped inside busser for its own
tests, not something anyone installed. `busser test` already passes over it, so
listing it as installed was inconsistent as well as confusing.

After:

```text
$ busser plugin list
Plugin  Version
bash    0.2.0
```

`busser test dummy` and `busser plugin install dummy` still work -- those name
the runner explicitly and do not go through the listing.