### PR TITLE
fix: use the Windows path separator in the bat binstub

### DIFF
--- a/lib/busser/command/setup.rb
+++ b/lib/busser/command/setup.rb
@@ -175,9 +175,15 @@ module Busser
         Gem.paths.home.dup.tap { |p| p.gsub!("/", "\\") if bat? }
       end
 
+      # The separator differs by platform, and the bat binstub is generated on
+      # and for Windows, where RubyGems splits GEM_PATH on ";". Joining with
+      # ":" there produced one unusable entry -- every Windows path already
+      # contains a colon after its drive letter -- so the isolated gem
+      # environment the binstub exists to create silently did not exist.
+      #
       # @return [String] the gem path the binstub exports
       def gem_path
-        Gem.paths.path.join(":").dup.tap { |p| p.gsub!("/", "\\") if bat? }
+        Gem.paths.path.join(bat? ? ";" : ":").dup.tap { |p| p.gsub!("/", "\\") if bat? }
       end
 
       # @return [String] directory holding the real busser executable

--- a/spec/busser/command/setup_spec.rb
+++ b/spec/busser/command/setup_spec.rb
@@ -96,6 +96,27 @@ describe Busser::Command::Setup do
       end
     end
 
+    # Windows RubyGems splits GEM_PATH on ";". Joining with ":" produced one
+    # unusable entry, because every Windows path already contains a colon after
+    # its drive letter -- so the isolated gem environment silently did not
+    # exist and Busser resolved gems from wherever it happened to land.
+    it "separates GEM_PATH entries with the Windows separator" do
+      Gem.paths.stubs(:path).returns(["C:/Ruby34/lib/ruby/gems", "C:/Users/kitchen/.gem"])
+      run_setup(type: "bat")
+
+      _(binstub_body).must_include(
+        'SET "GEM_PATH=C:\\Ruby34\\lib\\ruby\\gems;C:\\Users\\kitchen\\.gem"'
+      )
+    end
+
+    it "does not separate GEM_PATH entries with a colon" do
+      Gem.paths.stubs(:path).returns(["C:/a", "C:/b"])
+      run_setup(type: "bat")
+
+      gem_path = binstub_body[/^SET "GEM_PATH=(.*)"$/, 1]
+      _(gem_path.split(";").length).must_equal 2
+    end
+
     def binstub
       File.join(@tmpdir, "bin", "busser.bat")
     end


### PR DESCRIPTION
fix: use the Windows path separator in the bat binstub

`busser setup --type bat` writes a batch binstub whose whole purpose is to give
Busser an isolated gem environment on the machine under test. It built GEM_PATH
by joining the entries with `":"`:

```bat
SET "GEM_PATH=C:\Ruby34\lib\ruby\gems:C:\Users\kitchen\.gem"
```

Windows RubyGems splits GEM_PATH on `";"`, so it read that as a single entry --
and every Windows path already contains a colon after its drive letter, so the
result is not a path at all. The isolation the binstub exists to provide
silently did not happen, and Busser resolved gems from wherever it landed.

The bourne binstub is unaffected and keeps `":"`.

Two specs pin it: the joined value uses `";"`, and splitting the emitted
GEM_PATH on `";"` yields the number of entries that went in. Reverting the fix
fails both.