### PR TITLE
fix: bring the generated plugin scaffold up to date

### DIFF
--- a/spec/busser/command/plugin_create_spec.rb
+++ b/spec/busser/command/plugin_create_spec.rb
@@ -86,12 +86,24 @@ describe Busser::Command::PluginCreate do
       end
     end
 
-    it "depends on what the generated Rakefile needs" do
+    # These moved into the Gemfile, so the gemspec declares only what a
+    # consumer of the gem needs at runtime -- matching the busser-* plugins.
+    it "leaves development dependencies out of the gemspec" do
       generate
 
-      _(dev_dependencies).must_include "rake"
-      _(dev_dependencies).must_include "cucumber"
-      _(dev_dependencies).must_include "aruba"
+      _(dev_dependencies).must_be_empty
+    end
+
+    # busser-bash resolved busser 0.6.0 and failed its own suite because the
+    # requirement was open. A generated plugin should not start there.
+    it "requires a busser new enough to run the generated features" do
+      generate
+
+      busser = gemspec.dependencies.find { |d| d.name == "busser" }
+
+      _(busser).wont_be_nil
+      _(busser.requirement.satisfied_by?(Gem::Version.new("0.9.0"))).must_equal true
+      _(busser.requirement.satisfied_by?(Gem::Version.new("0.6.0"))).must_equal false
     end
 
     it "states a supported Ruby version" do
@@ -110,6 +122,25 @@ describe Busser::Command::PluginCreate do
     def dev_dependencies
       gemspec.development_dependencies.map(&:name)
     end
+  end
+
+  describe "the generated Gemfile" do
+
+    it "declares what the generated Rakefile needs" do
+      generate
+
+      body = File.read(File.join(plugin_dir, "Gemfile"))
+
+      %w{rake cucumber aruba}.each { |g| _(body).must_include "'#{g}'" }
+    end
+
+    # cucumber needs base64 on Ruby 4.0, where it is no longer a default gem.
+    it "declares base64" do
+      generate
+
+      _(File.read(File.join(plugin_dir, "Gemfile"))).must_include "'base64'"
+    end
+
   end
 
   describe "the generated project" do

--- a/templates/plugin/Gemfile.erb
+++ b/templates/plugin/Gemfile.erb
@@ -1,3 +1,10 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'aruba', '>= 2.4'
+  gem 'base64', '>= 0.3' # cucumber needs it; not a default gem on Ruby 4.0
+  gem 'cucumber', '>= 11.1'
+  gem 'rake', '>= 13.4'
+end

--- a/templates/plugin/Rakefile.erb
+++ b/templates/plugin/Rakefile.erb
@@ -2,7 +2,11 @@ require "bundler/gem_tasks"
 require "cucumber/rake/task"
 
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = ["features", "-x", "--format progress", "--no-color"]
+  # --strict-undefined so the scenarios generated with <YOUR_FILE> placeholders
+  # fail until they are filled in. Undefined steps otherwise pass silently, and
+  # a new plugin reports a green suite that asserts nothing.
+  t.cucumber_opts = ["features", "--format progress", "--fail-fast",
+                     "--strict-undefined"]
 end
 
 desc "Run all test suites"

--- a/templates/plugin/features_env.rb.erb
+++ b/templates/plugin/features_env.rb.erb
@@ -1,13 +1,8 @@
 require "aruba/cucumber"
 require "busser/cucumber"
 
+# Installing a plugin and its gems into a cold sandbox does not fit in aruba's
+# 15 second default.
 Aruba.configure do |config|
-  config.exit_timeout = 20
-end
-
-After do |s|
-  # Tell Cucumber to quit after this scenario is done - if it failed.
-  # This is useful to inspect the 'tmp/aruba' directory before any other
-  # steps are executed and clear it out.
-  Cucumber.wants_to_quit = true if s.failed?
+  config.exit_timeout = 60
 end

--- a/templates/plugin/gemspec.erb
+++ b/templates/plugin/gemspec.erb
@@ -15,15 +15,11 @@ Gem::Specification.new do |spec|
   spec.license       = '<%= config[:license_spdx] %>'
 <% end -%>
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = []
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 3.2'
 
-  spec.add_dependency 'busser'
-
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'aruba', '>= 2.0'
-  spec.add_development_dependency 'cucumber', '>= 9.0'
+  spec.add_dependency 'busser', '>= 0.9.0'
 end

--- a/templates/plugin/github_workflow.yml.erb
+++ b/templates/plugin/github_workflow.yml.erb
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
fix: bring the generated plugin scaffold up to date

`busser plugin create` was still generating projects against conventions the
busser-* plugins have all since moved off, so a new plugin started life stale.

**No floor on busser.** The generated gemspec asked for `busser` with no version
requirement. That is how busser-bash ended up resolving 0.6.0 and failing its
own suite. Now `>= 0.9.0`.

**Stale test tooling.** cucumber `>= 9.0` became `>= 11.1`; aruba and rake got
floors; `base64` was missing entirely, which cucumber needs on Ruby 4.0.

**Development dependencies moved into Gemfile groups**, matching every plugin in
the family, so the gemspec declares only what a consumer needs at runtime.

**The Rakefile carried two things already removed elsewhere**: `-x`
(`--expand`, which only affects Scenario Outline output and there are none) and
`Cucumber.wants_to_quit`, replaced by cucumber's own `--fail-fast`.

**aruba's timeout was 20 seconds.** Installing a plugin and its gems into a cold
sandbox does not reliably fit in that -- it is what made the real plugins flaky
on CI. Now 60.

**The CI matrix stopped at Ruby 3.4** while the gemspec and the rest of the
family support through 4.0.

## The placeholders were silently green

The generated `test_command.feature` ships two scenarios with `<YOUR_FILE>` and
`TEST FILE CONTENT` placeholders for the author to fill in. Undefined steps do
not fail cucumber by default, so a freshly generated plugin reported:

```text
4 scenarios (2 undefined, 2 passed)
```

and **exited 0**. An author who never filled them in had green CI proving
nothing, indefinitely. `--strict-undefined` makes the unfilled placeholders fail,
which is what a scaffold with TODOs in it should do -- verified end to end: the
generated project now exits 2 until the steps are written.